### PR TITLE
Add F# / OCaml mode

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -127,6 +127,10 @@ export const LANGUAGES = [
     module: 'fortran'
   },
   {
+    name: 'F# / OCaml',
+    module: 'mllike'
+  },
+  {
     name: 'Go',
     module: 'go'
   },


### PR DESCRIPTION
Adds F# and OCaml support by using CodeMirror's `mllike` mode - https://github.com/codemirror/CodeMirror/tree/master/mode/mllike