### PR TITLE
Use production build of React

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,14 @@
+const Uglify = require('uglifyjs-webpack-plugin')
+
 module.exports = {
   // TODO remove `next.configs.js` when this closes: https://github.com/zeit/next.js/issues/1195
-  webpack (cfg) {
-    cfg.plugins = cfg.plugins
-      .filter(plugin => (plugin.constructor.name !== 'UglifyJsPlugin'))
-    return cfg
+  webpack: function(c) {
+    c.plugins = c.plugins.filter(
+      plugin => plugin.constructor.name !== 'UglifyJsPlugin'
+    )
+
+    c.plugins.push(new Uglify())
+
+    return c
   },
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "react-spinner": "^0.2.7",
     "react-syntax-highlight": "^0.0.6",
     "tohash": "^1.0.2",
-    "twitter": "^1.7.1"
+    "twitter": "^1.7.1",
+    "uglifyjs-webpack-plugin": "1.0.0-beta.1"
   },
   "now": {
     "env": {
@@ -43,5 +44,6 @@
       "TWITTER_ACCESS_TOKEN_KEY": "@twitter-access-token-key",
       "TWITTER_ACCESS_TOKEN_SECRET": "@twitter-access-token-secret"
     }
-  }
+  },
+  "devDependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,6 +1055,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@~2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3590,6 +3594,13 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
+uglify-es@^3.0.21:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.1.2.tgz#b22cfca950f0632092aff42bb46979d83b5ec6f5"
+  dependencies:
+    commander "~2.11.0"
+    source-map "~0.5.1"
+
 uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -3602,6 +3613,14 @@ uglify-js@^2.8.29:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+uglifyjs-webpack-plugin@1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.0-beta.1.tgz#595c14d8b85bedd708ab7a6e811894fbe0e69890"
+  dependencies:
+    source-map "^0.5.6"
+    uglify-es "^3.0.21"
+    webpack-sources "^1.0.1"
 
 uglifyjs-webpack-plugin@^0.4.6:
   version "0.4.6"


### PR DESCRIPTION
Switch the temp strategy in `next.config.js` to use the production version of React from [here](https://github.com/zeit/next.js/issues/1195#issuecomment-326901737)

To avoid this 👇
<img width="1182" alt="screen shot 2017-09-25 at 18 13 45" src="https://user-images.githubusercontent.com/784056/30819033-bd7faf24-a21d-11e7-9ae2-a5047fb310e0.png">
