### PR TITLE
Add `cross-env` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "start": "cross-env NODE_ENV=production node server.js",
     "deploy": "now --public",
     "prettier": "prettier --config .prettierrc --write *.js {components,handlers,lib,pages}/*.js",
     "lint": "prettier --config .prettierrc -l *.js {components,handlers,lib,pages}/*.js"
@@ -39,6 +39,7 @@
     "twitter": "^1.7.1"
   },
   "devDependencies": {
+    "cross-env": "^5.0.5",
     "prettier": "^1.7.2",
     "uglifyjs-webpack-plugin": "1.0.0-beta.1",
     "webpack": "^3.6.0"


### PR DESCRIPTION
Unlike most, I don't use Bash on Windows, so running `yarn build` fails midway. This small PR makes it so you can have a single command without worrying about setting or using the environment variable properly for the platform.

Thanks :heart: