### PR TITLE
Fix contribute section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have discovered a bug or have a feature suggestion, feel free to create a
 
 If you'd like to make some changes yourself, see the following:
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
-2. Build and start the application: `yarn build && yarn dev`
+2. Build and start the application: `yarn dev`
 3. Finally, submit a [pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) with your changes!
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you have discovered a bug or have a feature suggestion, feel free to create a
 
 If you'd like to make some changes yourself, see the following:
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device
-2. Build and start the application: `yarn build && yarn start`
+2. Build and start the application: `yarn build && yarn dev`
 3. Finally, submit a [pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) with your changes!
 
 ## Authors


### PR DESCRIPTION
**Problem**
On the [contribute section](https://github.com/dawnlabs/carbon#contribute), there is a instruction to start application, but this command is wrong. The correct is [`yarn dev`](https://github.com/dawnlabs/carbon/blob/master/package.json#L7).

**Solution**
Change `yarn start` to `yarn dev`.