### PR TITLE
Add more JavaScript-like languages

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -182,6 +182,12 @@ export const LANGUAGES = [
     mode: 'javascript'
   },
   {
+    name: 'JSON',
+    mode: 'javascript',
+    mime: 'application/json',
+    short: 'json'
+  },
+  {
     name: 'JSX',
     mode: 'jsx'
   },
@@ -279,6 +285,12 @@ export const LANGUAGES = [
   {
     name: 'TCL',
     mode: 'tcl'
+  },
+  {
+    name: 'TypeScript',
+    mode: 'javascript',
+    mime: 'application/typescript',
+    short: 'typescript'
   },
   {
     name: 'VB.NET',


### PR DESCRIPTION
This adds `JSON` and `TypeScript` to this list of languages.

### JSON
![json](https://user-images.githubusercontent.com/10191084/31048952-1abfae3c-a5de-11e7-9918-e9ca4c02e5e2.png)

### TypeScript
![typescript](https://user-images.githubusercontent.com/10191084/31048951-19fa4516-a5de-11e7-91d5-834b6458d810.png)
