### PR TITLE
[PoC] Preconfigured Editor

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -11,3 +11,54 @@ const parse = v => {
 
 export const getState = morph.compose(parse, morph.get(KEY))
 export const saveState = (window, v) => assign(window, JSON.stringify(v))
+
+export const defaults = (value, defaultValue) => {
+  if (typeof value === 'undefined') {
+    return defaultValue
+  }
+
+  return value
+}
+
+const asBoolean = value => (value ? value === 'true' : true)
+const identity = value => value
+
+export const queryToProps = function(query) {
+  const mappings = {
+    bg: {
+      key: 'background',
+      transform: value => (value.startsWith('#') ? value : `#${value}`)
+    },
+    theme: 'theme',
+    lang: 'language',
+    shadow: {
+      key: 'dropShadow',
+      transform: asBoolean
+    },
+    wc: {
+      key: 'windowControls',
+      transform: asBoolean
+    },
+    vp: 'paddingVertical',
+    hp: 'paddingHorizontal'
+  }
+
+  const props = Object.keys(query).reduce((settings, key) => {
+    let propMapping = mappings[key]
+
+    if (!propMapping) {
+      return settings
+    }
+
+    if (typeof propMapping === 'string') {
+      propMapping = { key: propMapping, transform: identity }
+    }
+
+    const propKey = propMapping.key
+    const value = propMapping.transform(query[key])
+
+    return Object.assign(settings, { [propKey]: value })
+  }, {})
+
+  return props
+}

--- a/pages/preconfigured-editor.js
+++ b/pages/preconfigured-editor.js
@@ -1,0 +1,116 @@
+// Theirs
+import React from 'react'
+import domtoimage from 'dom-to-image'
+
+// Ours
+import Page from '../components/Page'
+import Carbon from '../components/Carbon'
+
+import { THEMES, DEFAULT_LANGUAGE, COLORS, DEFAULT_CODE } from '../lib/constants'
+
+import api from '../lib/api'
+import { queryToProps, defaults } from '../lib/util'
+
+class ConfigurableEditor extends React.Component {
+  /* pathname, asPath, err, req, res */
+  static async getInitialProps({ req }) {
+    const { query } = req
+    const props = queryToProps(query)
+
+    try {
+      if (query.gist) {
+        const content = await api.getGist(query.gist)
+        return Object.assign({ content }, props)
+      }
+    } catch (e) {
+      console.log(e)
+    }
+
+    return props
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      background: defaults(props.background, '#ABB8C3'),
+      theme: defaults(props.theme, THEMES.seti.id),
+      language: defaults(props.language, DEFAULT_LANGUAGE),
+      dropShadow: defaults(props.dropShadow, true),
+      windowControls: defaults(props.windowControls, true),
+      paddingVertical: defaults(props.paddingVertical, '48px'),
+      paddingHorizontal: defaults(props.paddingHorizontal, '32px'),
+      uploading: false,
+      code: props.content
+    }
+
+    this.save = this.save.bind(this)
+    this.updateCode = this.updateCode.bind(this)
+  }
+
+  componentWillMount() {
+    if (typeof window !== 'undefined') {
+      window.SET_CODE = code => this.updateCode(code)
+      window.GET_IMAGE = () => this.getCarbonImage()
+    }
+  }
+
+  getCarbonImage() {
+    const node = document.getElementById('section')
+
+    const config = {
+      style: {
+        transform: 'scale(2)',
+        'transform-origin': 'center'
+      },
+      width: node.offsetWidth * 2,
+      height: node.offsetHeight * 2
+    }
+
+    return domtoimage.toPng(node, config)
+  }
+
+  updateCode(code) {
+    this.setState({ code })
+  }
+
+  save() {
+    this.getCarbonImage().then(dataUrl => {
+      const link = document.createElement('a')
+      link.download = 'carbon.png'
+      link.href = dataUrl
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+    })
+  }
+
+  render() {
+    return (
+      <Page>
+        <div id="editor">
+          <Carbon config={this.state} updateCode={this.updateCode}>
+            {this.state.code || DEFAULT_CODE}
+          </Carbon>
+        </div>
+        <style jsx>
+          {`
+            #editor {
+              background: ${COLORS.BLACK};
+              border: 3px solid ${COLORS.SECONDARY};
+              border-radius: 8px;
+              padding: 16px;
+            }
+
+            .buttons {
+              display: flex;
+              margin-left: auto;
+            }
+          `}
+        </style>
+      </Page>
+    )
+  }
+}
+
+export default ConfigurableEditor

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ app.prepare().then(() => {
   server.use(morgan('tiny'))
 
   server.get('/about', (req, res) => app.render(req, res, '/about'))
+  server.get('/preconfigured-editor', (req, res) => app.render(req, res, '/preconfigured-editor'))
 
   // if root, render webpage from next
   server.get('/*', (req, res) => app.render(req, res, '/', req.query))


### PR DESCRIPTION
In order to enable features like #48 and #52 (and potentially #75, once it's clear how to combine localStorage and query string settings), there is a need to use this app in a more "programmatic" approach than currently possible.

For now I added a new endpoint, which is a "bare minimum version" of the editor. Ideally the shared functionality could be abstracted and reused by both editors.
It could also be extended to display the settings and update the query string whenever a setting changes.

Most important difference to the current editor is `componentWillMount`, which exposes two methods on the `window` object, which can be used to instrument the editor.

I built a [small server](https://github.com/zcei/carbon-server) which makes use of those methods to render the images on server side: 

```sh
curl \
  -X POST \
  -d 'const foo = bar' \
  https://carbon-server-ezesmrobex.now.sh/?wc=false&theme=ambiance
```

⚠️ This PR is not intended to be merged immediately, but to share my state early in order to gather feedback.