### PR TITLE
added button hover and adjusted colorpicker alignment

### DIFF
--- a/components/Button.js
+++ b/components/Button.js
@@ -1,33 +1,60 @@
 import React from 'react'
 import { COLORS } from '../lib/constants'
 
-export default props => (
-  <button
-    onClick={props.onClick}
-    style={Object.assign(
-      {
-        background: COLORS.BLACK,
-        color: props.color,
-        border: `0.5px solid ${props.color}`
-      },
-      props.style
-    )}
-  >
-    <span>{props.title}</span>
-    <style jsx>{`
-      button {
-        cursor: pointer;
-        outline: none;
-        height: 100%;
-        padding: 0 16px;
-        border-radius: 3px;
-        user-select: none;
-      }
+class Button extends React.Component {
+  constructor(props) {
+    super(props)
 
-      button > span {
-        font-size: 14px;
-        line-height: 1;
-      }
-    `}</style>
-  </button>
-)
+    this.state = {
+      color: this.props.color
+    }
+
+    this.btnHoverOn = this.btnHoverOn.bind(this)
+    this.btnHoverOff = this.btnHoverOff.bind(this)
+  }
+
+  btnHoverOn() {
+    this.setState({ color: COLORS.PRIMARY })
+  }
+
+  btnHoverOff() {
+    this.setState({ color: this.props.color })
+  }
+
+  render() {
+    return (
+      <button
+        onMouseEnter={this.btnHoverOn}
+        onMouseLeave={this.btnHoverOff}
+        onClick={this.props.onClick}
+        style={Object.assign(
+          {
+            background: COLORS.BLACK,
+            color: this.state.color,
+            border: `0.5px solid ${this.state.color}`
+          },
+          this.props.style
+        )}
+      >
+        <span>{this.props.title}</span>
+        <style jsx>{`
+          button {
+            cursor: pointer;
+            outline: none;
+            height: 100%;
+            padding: 0 16px;
+            border-radius: 3px;
+            user-select: none;
+          }
+
+          button > span {
+            font-size: 14px;
+            line-height: 1;
+          }
+        `}</style>
+      </button>
+    )
+  }
+}
+
+export default Button

--- a/components/ColorPicker.js
+++ b/components/ColorPicker.js
@@ -67,7 +67,7 @@ class ColorPicker extends React.Component {
 
           .bg-color {
             cursor: pointer;
-            height: 100%;
+            height: 99.9%;
             width: 36px;
             border-radius: 0px 2px 2px 0px;
           }

--- a/pages/editor.js
+++ b/pages/editor.js
@@ -72,7 +72,7 @@ class Editor extends React.Component {
     saveState(localStorage, s)
   }
 
-  getCarbonImage () {
+  getCarbonImage() {
     const node = document.getElementById('section')
 
     const config = {


### PR DESCRIPTION
Hi, I have just added button hover effects and minor alignment on the colorpicker block.
I've attached a few images here.

Colorpicker block before
![bgcolorbefore](https://user-images.githubusercontent.com/6908845/31091464-b2693230-a7c8-11e7-9e96-7263dcd8b06f.png)
Colorpicker block after
![bgcolorafter](https://user-images.githubusercontent.com/6908845/31091500-d6103be8-a7c8-11e7-931a-765997f44867.png)

No hover effect
![nohovercolor](https://user-images.githubusercontent.com/6908845/31091545-f6e5e6a6-a7c8-11e7-85e4-35171f90745e.jpg)
With hover effect
![withhovercolor](https://user-images.githubusercontent.com/6908845/31091562-0815b456-a7c9-11e7-862a-4203111f92f9.jpg)

I think this addresses the issue [#83](https://github.com/dawnlabs/carbon/issues/83).