### PR TITLE
fix cursor jumping at the end after every editor update

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -102,7 +102,7 @@ class Carbon extends React.Component {
           {config.windowControls ? <WindowControls theme={config.windowTheme} /> : null}
           <CodeMirror
             className={`CodeMirror__container window-theme__${config.windowTheme}`}
-            onChange={(editor, meta, code) => this.codeUpdated(code)}
+            onBeforeChange={(editor, meta, code) => this.codeUpdated(code)}
             value={this.props.children}
             options={options}
           />

--- a/lib/react-codemirror.js
+++ b/lib/react-codemirror.js
@@ -1,6 +1,6 @@
 // For SSR, CodeMirror will throw an error, so return a div instead
 let CodeMirror = 'div'
 if (typeof window !== 'undefined' && typeof window.navigator !== 'undefined') {
-  CodeMirror = require('react-codemirror2').UnControlled
+  CodeMirror = require('react-codemirror2').Controlled
 }
 export default CodeMirror


### PR DESCRIPTION
Currently the cursor constantly jumps at the end everytime you press a key in the editor

My changes is supposed to prevent that