### PR TITLE
Make default font one without ligatures

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -26,7 +26,7 @@ const DEFAULT_SETTINGS = {
   theme: 'seti',
   windowTheme: 'none',
   language: DEFAULT_LANGUAGE,
-  fontFamily: 'Fira Code',
+  fontFamily: 'Hack',
   fontSize: '14px'
 }
 


### PR DESCRIPTION
CC: @chrissimpkins

This removes a font with ligatures as the default, but lets people opt-in to it, since others have wanted that in the past: https://github.com/dawnlabs/carbon/issues/30