### PR TITLE
Fix boolean params

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -7,26 +7,32 @@ if (typeof window !== 'undefined') {
   history = createHistory()
 }
 
-const mapper = new Morph()
+const mapper = new Morph({
+  types: {
+    bool: v => (v ? v === true || v === 'true' : v)
+  }
+})
 
 const mappings = [
-  'bg:backgroundColor',
-  't:theme',
-  'l:language',
-  'ds:dropShadow',
-  'wc:windowControls',
-  'wa:widthAdjustment',
-  'pv:paddingVertical',
-  'ph:paddingHorizontal',
-  'ln:lineNumbers',
-  'code:code'
+  { field: 'bg:backgroundColor' },
+  { field: 't:theme' },
+  { field: 'l:language' },
+  { field: 'ds:dropShadow', type: 'bool' },
+  { field: 'wc:windowControls', type: 'bool' },
+  { field: 'wa:widthAdjustment', type: 'bool' },
+  { field: 'pv:paddingVertical' },
+  { field: 'ph:paddingHorizontal' },
+  { field: 'ln:lineNumbers', type: 'bool' },
+  { field: 'code:code' }
 ]
 
-const reverseMappings = mappings.map(field =>
-  field
-    .split(':')
-    .reverse()
-    .join(':')
+const reverseMappings = mappings.map(mapping =>
+  Object.assign({}, mapping, {
+    field: mapping.field
+      .split(':')
+      .reverse()
+      .join(':')
+  })
 )
 
 const keysToQuery = keys =>

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -9,7 +9,10 @@ if (typeof window !== 'undefined') {
 
 const mapper = new Morph({
   types: {
-    bool: v => (v ? v === true || v === 'true' : v)
+    bool: v => {
+      if (v === 'false') return false
+      return Boolean(v)
+    }
   }
 })
 


### PR DESCRIPTION
This PR addresses an issue with boolean query parameters like window controls, line numbers, etc. They were not being parsed as booleans, so if they were set to `false` in the url, they were not being reflected properly in the rendering because `"false"` is truthy.

This PR updates the routing code to correctly parse those params to the appropriate values so they are reflected in the rendering.