### PR TITLE
Fix character encoding of editor text

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -46,6 +46,7 @@ const keysToQuery = keys =>
 
 export const getQueryStringState = query => {
   const state = mapper.map(mappings, query)
+  deserializeCode(state)
 
   Object.keys(state).forEach(key => {
     if (state[key] === '') state[key] = undefined
@@ -54,7 +55,20 @@ export const getQueryStringState = query => {
   return state
 }
 
-export const updateQueryString = state =>
+export const updateQueryString = state => {
+  let mappedState = mapper.map(reverseMappings, state)
+  serializeCode(mappedState)
+
   history.replace({
-    search: encodeURI(keysToQuery(mapper.map(reverseMappings, state)))
+    search: encodeURI(keysToQuery(mappedState))
   })
+}
+
+// private
+function serializeCode(state) {
+  if (state.code) state.code = encodeURIComponent(state.code)
+}
+
+function deserializeCode(state) {
+  if (state.code) state.code = decodeURIComponent(state.code)
+}


### PR DESCRIPTION
We were running `encodeURI` on the whole query state which only encodes certain characters (like whitespace). `encodeURIComponent` is needed to completely encode all characters.

Fixes #229 