### PR TITLE
Filter language list

### DIFF
--- a/pages/editor.js
+++ b/pages/editor.js
@@ -188,6 +188,14 @@ class Editor extends React.Component {
     }
   }
 
+  updateLanguageList(language) {
+    const langItem = new RegExp(language.key, 'i')
+    const match = LANGUAGES.find(lang => langItem.test(lang.text))
+    if (match) {
+      this.updateSetting('language', match.mime || match.mode)
+    }
+  }
+
   updateTheme(theme) {
     this.updateSetting('theme', theme.id)
   }
@@ -217,6 +225,7 @@ class Editor extends React.Component {
                 LANGUAGE_MODE_HASH[this.state.language]
               }
               list={LANGUAGES}
+              onKeyDown={this.updateLanguageList}
               onChange={this.updateLanguage}
             />
             <BackgroundSelect

--- a/pages/editor.js
+++ b/pages/editor.js
@@ -188,16 +188,16 @@ class Editor extends React.Component {
     }
   }
 
+  updateTheme(theme) {
+    this.updateSetting('theme', theme.id)
+  }
+
   updateLanguageList(language) {
     const langItem = new RegExp(language.key, 'i')
     const match = LANGUAGES.find(lang => langItem.test(lang.text))
     if (match) {
       this.updateSetting('language', match.mime || match.mode)
     }
-  }
-
-  updateTheme(theme) {
-    this.updateSetting('theme', theme.id)
   }
 
   updateLanguage(language) {


### PR DESCRIPTION
Hi!

I really like carbon, and I missed having the ability to filter the language list.

With your awesome permission, I would like you to see what I did to address that. 

![demo](https://user-images.githubusercontent.com/16037265/38104118-ed31c748-3390-11e8-9784-5bfc0a5c3ca2.gif)

Thanks! 🍻 

Basically just added a keyDown function that filters using a RegExp 😃 