### PR TITLE
improve first meaningful paint on browser

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -1,4 +1,3 @@
-import * as hljs from 'highlight.js'
 import React, { PureComponent } from 'react'
 import Spinner from 'react-spinner'
 import ResizeObserver from 'resize-observer-polyfill'
@@ -51,13 +50,20 @@ class Carbon extends PureComponent {
     this.props.updateTitleBar(newTitle)
   }
 
+  async getHighlightLang(code = '') {
+    if (!this.hljs) {
+      this.hljs = await import('highlight.js')
+    }
+    return this.hljs.highlightAuto(code).language
+  }
+
   handleLanguageChange = debounce(
-    (newCode, config) => {
+    async (newCode, config) => {
       const props = (config && config.customProps) || this.props
 
       if (props.config.language === 'auto') {
         // try to set the language
-        const detectedLanguage = hljs.highlightAuto(newCode).language
+        const detectedLanguage = await this.getHighlightLang(newCode)
         const languageMode =
           LANGUAGE_MODE_HASH[detectedLanguage] || LANGUAGE_NAME_HASH[detectedLanguage]
 

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -7,60 +7,65 @@ import Typography from './style/Typography'
 import '../static/react-crop.css'
 import '../static/react-spinner.css'
 
-export default () => (
-  <div className="meta">
-    <Head>
-      <meta charSet="utf-8" />
-      <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <meta
-        name="description"
-        content="Carbon is the easiest way to create and share beautiful images of your source code."
-      />
-      <meta name="application-name" content="Carbon" />
-      <meta name="twitter:title" content="Carbon" />
-      <meta
-        name="twitter:description"
-        content="Carbon is the easiest way to create and share beautiful images of your source code."
-      />
-      <meta name="og:title" content="Carbon" />
-      <meta
-        name="og:description"
-        content="Carbon is the easiest way to create and share beautiful images of your source code."
-      />
-      <meta name="og:image" content="/static/banner.png" />
-      <meta name="theme-color" content="#121212" />
-      <title>Carbon</title>
-      <link rel="shortcut icon" href="/static/favicon.ico" />
-      <link rel="stylesheet" href="/_next/static/style.css" />
-      <link
-        rel="stylesheet"
-        href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.min.css"
-      />
-      <link
-        rel="stylesheet"
-        href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.30.0/theme/solarized.min.css"
-      />
-      {THEMES.filter(t => t.hasStylesheet !== false).map(theme => (
-        <link
-          key={theme.id}
-          rel="stylesheet"
-          href={
-            theme.link ||
-            `//cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/theme/${theme.id}.min.css`
-          }
+export default () => {
+  const onBrowser = typeof window !== 'undefined'
+  return (
+    <div className="meta">
+      <Head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="description"
+          content="Carbon is the easiest way to create and share beautiful images of your source code."
         />
-      ))}
-    </Head>
-    <Reset />
-    <Font />
-    <Typography />
-    <style jsx>
-      {`
-        .meta {
-          display: none;
-        }
-      `}
-    </style>
-  </div>
-)
+        <meta name="application-name" content="Carbon" />
+        <meta name="twitter:title" content="Carbon" />
+        <meta
+          name="twitter:description"
+          content="Carbon is the easiest way to create and share beautiful images of your source code."
+        />
+        <meta name="og:title" content="Carbon" />
+        <meta
+          name="og:description"
+          content="Carbon is the easiest way to create and share beautiful images of your source code."
+        />
+        <meta name="og:image" content="/static/banner.png" />
+        <meta name="theme-color" content="#121212" />
+        <title>Carbon</title>
+        <link rel="shortcut icon" href="/static/favicon.ico" />
+        <link rel="stylesheet" href="/_next/static/style.css" />
+        <link
+          rel="stylesheet"
+          href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.min.css"
+        />
+        <link
+          rel="stylesheet"
+          href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.30.0/theme/solarized.min.css"
+        />
+        {onBrowser
+          ? THEMES.filter(t => t.hasStylesheet !== false).map(theme => (
+              <link
+                key={theme.id}
+                rel="stylesheet"
+                href={
+                  theme.link ||
+                  `//cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/theme/${theme.id}.min.css`
+                }
+              />
+            ))
+          : null}
+      </Head>
+      <Reset />
+      <Font />
+      <Typography />
+      <style jsx>
+        {`
+          .meta {
+            display: none;
+          }
+        `}
+      </style>
+    </div>
+  )
+}


### PR DESCRIPTION
### Before (~2s)
<img width="450" alt="screen shot 2018-04-02 at 00 41 58" src="https://user-images.githubusercontent.com/3864761/38175509-007f6748-3610-11e8-9e3b-7450228a0ac6.png">

### After (~1s)
<img width="458" alt="screen shot 2018-04-02 at 00 41 10" src="https://user-images.githubusercontent.com/3864761/38175508-005168ca-3610-11e8-899b-f975fe296543.png">

☝️ both are tested on localhost (Chrome v65.0)
the green line is the first frame captured.

## Description
speed up by delaying codemirror theme & highlightjs (big lib)