### PR TITLE
fix issue #321 - load defaults, then localStorage, then url config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .next
 cypress/videos
 cypress/screenshots
+.idea

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -62,9 +62,8 @@ class Editor extends React.Component {
   }
 
   componentDidMount() {
-    // Load from localStorage instead of query params
+    // Load from localStorage and then URL params
     this.setState({
-      ...this.state,
       ...getState(localStorage),
       ...this.props.initialState
     })

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -41,14 +41,11 @@ const saveButtonOptions = {
 class Editor extends React.Component {
   constructor(props) {
     super(props)
-    this.state = Object.assign(
-      {
-        ...DEFAULT_SETTINGS,
-        uploading: false,
-        code: props.content
-      },
-      this.props.initialState
-    )
+    this.state = {
+      ...DEFAULT_SETTINGS,
+      uploading: false,
+      code: props.content
+    }
 
     this.save = this.save.bind(this)
     this.upload = this.upload.bind(this)
@@ -66,12 +63,11 @@ class Editor extends React.Component {
 
   componentDidMount() {
     // Load from localStorage instead of query params
-    if (!this.props.initialState) {
-      const state = getState(localStorage)
-      if (state) {
-        this.setState(state)
-      }
-    }
+    this.setState({
+      ...this.state,
+      ...getState(localStorage),
+      ...this.props.initialState
+    })
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
## Description
For IDEs that allow you to open selected code in Carbon, they only pass the language and the code. To avoid losing your localStorage config, the settings should be merged in the following order:

1. DEFAULT
2. localStorage
3. urlParams

This ensures that all required config is present and that url params trump all.