### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-If you have discovered a bug or have a feature suggestion, feel free to create an issue on Github.
+If you have discovered a bug or have a feature suggestion, feel free to create an issue on GitHub.
 
 If you'd like to make some changes yourself, see the following:
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device


### PR DESCRIPTION
Since the character `GitHub` in` CONTRIBUTING.md` which will be seen by outside engineers was not unified by `GitHub`, I made a PR.

Thank you.