### PR TITLE
Use gist language response - fix when no queryparams are given

### DIFF
--- a/cypress/integration/gist.js
+++ b/cypress/integration/gist.js
@@ -2,12 +2,11 @@
 /* global cy */
 import { editorVisible } from '../support'
 describe('Gist', () => {
-  const themeDropdown = () => cy.get('#toolbar .dropdown-container').first()
-
   it('Should pull text from the first Gist file', () => {
     cy.visit('/3208813b324d82a9ebd197e4b1c3bae8')
     editorVisible()
 
     cy.contains('Y-Combinator implemented in JavaScript')
+    cy.get('#downshift-input-Auto').should('have.value', 'JavaScript')
   })
 })

--- a/cypress/integration/gist.js
+++ b/cypress/integration/gist.js
@@ -7,6 +7,12 @@ describe('Gist', () => {
     editorVisible()
 
     cy.contains('Y-Combinator implemented in JavaScript')
+  })
+
+  it('Should pull the language from the first Gist file', () => {
+    cy.visit('/3208813b324d82a9ebd197e4b1c3bae8')
+    editorVisible()
+
     cy.get('#downshift-input-Auto').should('have.value', 'JavaScript')
   })
 })

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,7 +12,7 @@ class Index extends React.Component {
   static async getInitialProps({ asPath, query }) {
     const path = removeQueryString(asPath.split('/').pop())
     const queryParams = getQueryStringState(query)
-    const initialState = Object.keys(queryParams).length ? queryParams : null
+    const initialState = Object.keys(queryParams).length ? queryParams : {}
     try {
       // TODO fix this hack
       if (path.length >= 19 && path.indexOf('.') === -1) {


### PR DESCRIPTION
For example http://carbon.now.sh/3208813b324d82a9ebd197e4b1c3bae8 would still not set the language property because `initialState` is `null`.
