### PR TITLE
Added sTeX/LaTeX Language Support

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -274,6 +274,10 @@ export const LANGUAGES = [
     short: 'kotlin'
   },
   {
+    name: 'LaTeX',
+    mode: 'stex'
+  },
+  {
     name: 'Lisp',
     mode: 'commonlisp'
   },
@@ -366,10 +370,6 @@ export const LANGUAGES = [
   {
     name: 'SQL',
     mode: 'sql'
-  },
-  {
-    name: 'LaTeX',
-    mode: 'stex'
   },
   {
     name: 'Stylus',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -368,7 +368,7 @@ export const LANGUAGES = [
     mode: 'sql'
   },
   {
-    name: 'sTeX/LaTeX',
+    name: 'LaTeX',
     mode: 'stex'
   },
   {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -368,6 +368,10 @@ export const LANGUAGES = [
     mode: 'sql'
   },
   {
+    name: 'sTeX/LaTeX',
+    mode: 'stex'
+  },
+  {
     name: 'Stylus',
     mode: 'stylus',
     mime: 'stylus'


### PR DESCRIPTION
This PR adds the language support for sTeX/LaTeX.

## Description

The constant id for sTeX/LaTeX has been added which is supported in Codemirror.

This is how your latex code would look like in Carbon:

![carbon 1](https://user-images.githubusercontent.com/14239425/42206009-a2ad7856-7ec3-11e8-85a7-4cfc495cde1a.png)

Thanks.