### PR TITLE
Fix crash on up/down press in Dropdown

### DIFF
--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -16,9 +16,11 @@ class Dropdown extends PureComponent {
       if (Object.prototype.hasOwnProperty.call(changes, 'inputValue')) {
         if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
           inputValue = this.userInputtedValue
-        } else {
+        } else if (changes.type === Downshift.stateChangeTypes.changeInput) {
           inputValue = changes.inputValue
           this.userInputtedValue = changes.inputValue
+        } else {
+          inputValue = changes.inputValue
         }
       }
 
@@ -56,20 +58,21 @@ class Dropdown extends PureComponent {
   userInputtedValue = ''
 
   render() {
-    const { button, color, list, selected, onChange } = this.props
+    const { button, color, selected, onChange } = this.props
+    const { itemsToShow, inputValue } = this.state
 
-    const minWidth = calcMinWidth(button, selected, list)
+    const minWidth = calcMinWidth(button, selected, itemsToShow)
 
     return (
       <Downshift
-        inputValue={this.state.inputValue}
+        inputValue={inputValue}
         selectedItem={selected}
-        defaultHighlightedIndex={list.findIndex(it => it === selected)}
+        defaultHighlightedIndex={itemsToShow.findIndex(it => it === selected)}
         itemToString={item => item.name}
         onChange={onChange}
         onUserAction={this.onUserAction}
       >
-        {renderDropdown({ button, color, list: this.state.itemsToShow, selected, minWidth })}
+        {renderDropdown({ button, color, list: itemsToShow, selected, minWidth })}
       </Downshift>
     )
   }


### PR DESCRIPTION
Fixes #420 where the application crashes after selecting a dropdown item
and then pressing the up or down arrow keys.

## Description
The app would crash because the default highlighted index for the Dropdown was from `this.props.list` while the actual items being displayed were in `this.state.itemsToShow`.  When up/down was pressed this discrepancy would cause an error.

`this.userInputtedValue` also changed even on just clicking on an item rather than just manually typing the value.  Once the crash was fixed, this issue would mean the list would only show 1 item since it would think the user inputted the full word manually.
