### PR TITLE
Add optional timestamp to saved file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 cypress/videos
 cypress/screenshots
 .idea
+.DS_Store

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -142,9 +142,15 @@ class Editor extends React.Component {
 
   save({ id: format = 'png' }) {
     const link = document.createElement('a')
+    const timezoneOffset = (new Date()).getTimezoneOffset() * 60000
+    const timeString = (new Date(Date.now() - timezoneOffset))
+      .toISOString()
+      .slice(0, 19)
+      .replace(/:/g,'-')
+      .replace('T',' ')
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
-      link.download = `carbon.${format}`
+      link.download = `carbon ${timeString}.${format}`
       link.href = url
       document.body.appendChild(link)
       link.click()

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -147,8 +147,8 @@ class Editor extends React.Component {
     const timeString = (new Date(Date.now() - timezoneOffset)).toISOString()
       .slice(0, 19)
       .replace(/:/g,'-')
-      .replace('T',' ')
-    const timestamp = this.state.timestamp ? ` ${timeString}` : '';
+      .replace('T','_')
+    const timestamp = this.state.timestamp ? `_${timeString}` : ''
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
       link.download = `carbon${timestamp}.${format}`

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -142,15 +142,16 @@ class Editor extends React.Component {
 
   save({ id: format = 'png' }) {
     const link = document.createElement('a')
+
     const timezoneOffset = (new Date()).getTimezoneOffset() * 60000
-    const timeString = (new Date(Date.now() - timezoneOffset))
-      .toISOString()
+    const timeString = (new Date(Date.now() - timezoneOffset)).toISOString()
       .slice(0, 19)
       .replace(/:/g,'-')
       .replace('T',' ')
+    const timestamp = this.state.timestamp ? ` ${timeString}` : '';
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
-      link.download = `carbon ${timeString}.${format}`
+      link.download = `carbon${timestamp}.${format}`
       link.href = url
       document.body.appendChild(link)
       link.click()

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -114,6 +114,11 @@ class Settings extends React.Component {
               enabled={this.props.watermark}
               onChange={this.props.onChange.bind(null, 'watermark')}
             />
+            <Toggle
+              label="Timestamp file name"
+              enabled={this.props.timestamp}
+              onChange={this.props.onChange.bind(null, 'timestamp')}
+            />
             <ExportSizeSelect
               selected={this.props.exportSize || '2x'}
               onChange={this.props.onChange.bind(null, 'exportSize')}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -496,5 +496,6 @@ export const DEFAULT_SETTINGS = {
   exportSize: '2x',
   titleBar: '',
   watermark: false,
-  squaredImage: false
+  squaredImage: false,
+  timestamp: true
 }

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -36,7 +36,8 @@ const mappings = [
   { field: 'si:squaredImage', type: 'bool' },
   { field: 'code:code' },
   { field: 'es:exportSize' },
-  { field: 'wm:watermark', type: 'bool' }
+  { field: 'wm:watermark', type: 'bool' },
+  { field: 'ts:timestamp', type: 'bool' }
 ]
 
 const reverseMappings = mappings.map(mapping =>


### PR DESCRIPTION
## Motivation

I was using Carbon this week (great tool btw), and thought to myself that the user experience might be a bit better if the file names were timestamped, like how the native screen capture tool on macOS saves files as `Screen Shot 2018-07-13 at 1.47.37 AM` or how [MonoSnap](https://monosnap.com/welcome) saves files as `screencast 2018-07-12 14-24-21.mp4`

It's a minor improvement, but I personally find it easier to sort through multiple Carbon-generated files if they all have unique file names like this, since:
* Date/time is a lot easier to read through and gives more information than `carbon, carbon(1), carbon(2), etc.`.
* The order in which your files are displayed is consistent with time. If you instead save all files with the same name, you can get mixed up while deleting (e.g. if you have up to `carbon(7)`, but you delete `carbon(3)`, your next file will be saved as `carbon(3)`, which is mildly confusing).

## My changes

I added a few lines of code in the `save()` function within `Editor.js` that parse a timezone-adjusted ISO8601 time stamp (slightly formatted for readability). Of course, I also made it a toggle in the Settings so that it wasn't forced upon everyone.

## Result

Files are now saved in this format: `carbon yyyy-MM-dd hh-mm-ss.ext` (e.g. `carbon 2018-07-13 01-31-11.png`).

**P.S. I also added `.DS_Store` to the `.gitignore` since it was bugging me, but it's totally unrelated to the rest of this PR.**