### PR TITLE
fixes #432, Nim's syntax highlighting is not weird anymore

### DIFF
--- a/lib/custom/modes/nimrod.js
+++ b/lib/custom/modes/nimrod.js
@@ -8,7 +8,9 @@ CodeMirror.defineMode('nimrod', function(conf, parserConf) {
     return new RegExp('^((' + words.join(')|(') + '))\\b')
   }
 
-  var operators = new RegExp('\\=\\+\\-\\*\\/\\<\\>\\@\\$\\~\\&\\%\\|\\!\\?\\^\\:\\\\')
+  var ops = ['=', '+', '-', '*', '/', '<', '>', '@', '$', '~', '&', '%', '|', 
+    '?', '^', ':', '\\', '[', ']', '(', ')', ',', '{', '}', '.\\.', '.']
+  var operators = new RegExp(ops.map(function(op) { return '\\' + op; }).join('|'))
   var identifiers = new RegExp('^[_A-Za-z][_A-Za-z0-9]*')
 
   var commonkeywords = [


### PR DESCRIPTION
## result:

![nim-syntax](https://user-images.githubusercontent.com/2784755/42768604-2dc158aa-894a-11e8-99f6-808a2b0e33ca.png)


## Description
I changed the RegExp syntax to be more readable and improve maintanability