### PR TITLE
feat(save): add "copy" button

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -146,15 +146,9 @@ class Editor extends React.Component {
     const timestamp = this.state.timestamp ? `_${formatTimestamp()}` : ''
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
-      if (format === 'open ↗') {
-        link.href = url
-        link.target = '_blank'
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
-        return url;
+      if (format !== 'open ↗') {
+        link.download = `carbon${timestamp}.${format}`
       }
-      link.download = `carbon${timestamp}.${format}`
       link.href = url
       document.body.appendChild(link)
       link.click()

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -36,7 +36,7 @@ const saveButtonOptions = {
   button: true,
   color: '#c198fb',
   selected: { id: 'SAVE_IMAGE', name: 'Save Image' },
-  list: ['png', 'svg'].map(id => ({ id, name: id.toUpperCase() }))
+  list: ['png', 'svg', 'copy'].map(id => ({ id, name: id.toUpperCase() }))
 }
 
 class Editor extends React.Component {
@@ -146,6 +146,10 @@ class Editor extends React.Component {
     const timestamp = this.state.timestamp ? `_${formatTimestamp()}` : ''
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
+      if (format === 'copy') {
+        window.location = url;
+        return url;
+      }
       link.download = `carbon${timestamp}.${format}`
       link.href = url
       document.body.appendChild(link)

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -36,7 +36,7 @@ const saveButtonOptions = {
   button: true,
   color: '#c198fb',
   selected: { id: 'SAVE_IMAGE', name: 'Save Image' },
-  list: ['png', 'svg', 'copy'].map(id => ({ id, name: id.toUpperCase() }))
+  list: ['png', 'svg', 'open ↗'].map(id => ({ id, name: id.toUpperCase() }))
 }
 
 class Editor extends React.Component {
@@ -146,8 +146,12 @@ class Editor extends React.Component {
     const timestamp = this.state.timestamp ? `_${formatTimestamp()}` : ''
 
     return this.getCarbonImage({ format, type: 'blob' }).then(url => {
-      if (format === 'copy') {
-        window.location = url;
+      if (format === 'open ↗') {
+        link.href = url
+        link.target = '_blank'
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
         return url;
       }
       link.download = `carbon${timestamp}.${format}`


### PR DESCRIPTION
add a button to the save menu called "copy", which opens the raw image data in the window so users
can directly copy it for easy pasting into a variety of apps

Closes #49

There is currently not browser support for copying actual images, so this seems to be a reasonable workaround. Any thoughts?


![jul-25-2018 15-03-11](https://user-images.githubusercontent.com/582828/43221796-ec486ade-901b-11e8-8a15-1678d5eb3a03.gif)

<!---   Provide a general summary of your changes in the Title above
        Expand on it in the description below (if applicable)    -->
<!-- Attach a screenshot where applicable -->

## Description
<!--- Describe your changes -->