### PR TITLE
Issue #452: Fix 500 error with `%` in `code`.

### DIFF
--- a/lib/routing.js
+++ b/lib/routing.js
@@ -52,9 +52,8 @@ const reverseMappings = mappings.map(mapping =>
 export const serializeState = state => {
   const stateString = encodeURIComponent(JSON.stringify(state))
 
-  return encodeURIComponent(typeof window !== 'undefined'
-    ? btoa(stateString)
-    : Buffer.from(stateString).toString('base64')
+  return encodeURIComponent(
+    typeof window !== 'undefined' ? btoa(stateString) : Buffer.from(stateString).toString('base64')
   )
 }
 
@@ -80,7 +79,6 @@ export const getQueryStringState = query => {
   }
 
   const state = mapper.map(mappings, query)
-  deserializeCode(state)
 
   Object.keys(state).forEach(key => {
     if (state[key] === '') state[key] = undefined
@@ -92,19 +90,9 @@ export const getQueryStringState = query => {
 export const updateQueryString = state => {
   if (history.location.search.indexOf('react_perf') < 0) {
     const mappedState = mapper.map(reverseMappings, state)
-    serializeCode(mappedState)
 
     history.replace({
       search: encodeURI(keysToQuery(mappedState))
     })
   }
-}
-
-// private
-function serializeCode(state) {
-  if (state.code) state.code = encodeURIComponent(state.code)
-}
-
-function deserializeCode(state) {
-  if (state.code) state.code = decodeURIComponent(state.code)
 }


### PR DESCRIPTION
Fixes #452 . 

## Description

This PR removes `deserializeCode()` and `serializeCode()` since the passed arguments are already encoded/decoded when passed and they don't need to encode/decode if I understand it correctly.

Thank you in advance.