### PR TITLE
Allow Codemirror to highlight active lines

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -79,6 +79,7 @@ class Carbon extends PureComponent {
       scrollBarStyle: null,
       viewportMargin: Infinity,
       lineWrapping: true,
+      activeLine: true,
       extraKeys: {
         'Shift-Tab': 'indentLess'
       }


### PR DESCRIPTION
This just lets you highlight lines and keep the lines highlighted when you click away. You can still unhighlight them when you click on the editor.

@jakedex I think this behavior is pretty typical right? 

Closes #428