### PR TITLE
WIP: integration with prettier

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -217,13 +217,11 @@ class Editor extends React.Component {
   }
 
   format(code) {
-    formatCode(code)
-      .then(formatted => {
-        this.setState({ code: formatted })
-      })
-      .catch(err => {
-        console.error(err)
-      })
+    try {
+      this.setState({ code: formatCode(code) })
+    } catch (err) {
+      //
+    }
   }
 
   render() {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,7 +30,7 @@ import {
   DEFAULT_SETTINGS
 } from '../lib/constants'
 import { serializeState } from '../lib/routing'
-import { getState } from '../lib/util'
+import { getState, formatCode } from '../lib/util'
 
 const saveButtonOptions = {
   button: true,
@@ -62,6 +62,7 @@ class Editor extends React.Component {
     this.resetDefaultSettings = this.resetDefaultSettings.bind(this)
     this.getCarbonImage = this.getCarbonImage.bind(this)
     this.onDrop = this.onDrop.bind(this)
+    this.format = this.format.bind(this)
 
     this.setOffline = () => this.setState({ online: false })
     this.setOnline = () => this.setState({ online: true })
@@ -76,13 +77,13 @@ class Editor extends React.Component {
       online: Boolean(window && window.navigator && window.navigator.onLine)
     })
 
-    window.addEventListener('offline', this.setOffline);
-    window.addEventListener('online', this.setOnline);
+    window.addEventListener('offline', this.setOffline)
+    window.addEventListener('online', this.setOnline)
   }
 
   componentWillUnmount() {
-    window.removeEventListener('offline', this.setOffline);
-    window.removeEventListener('online', this.setOnline);
+    window.removeEventListener('offline', this.setOffline)
+    window.removeEventListener('online', this.setOnline)
   }
 
   componentDidUpdate() {
@@ -104,7 +105,7 @@ class Editor extends React.Component {
     if (isPNG) {
       document.querySelectorAll('.CodeMirror-line > span > span').forEach(n => {
         if (n.innerText && n.innerText.match(/%\S\S/)) {
-          n.innerText = encodeURIComponent(n.innerText);
+          n.innerText = encodeURIComponent(n.innerText)
         }
       })
     }
@@ -215,6 +216,16 @@ class Editor extends React.Component {
     }
   }
 
+  format(code) {
+    formatCode(code)
+      .then(formatted => {
+        this.setState({ code: formatted })
+      })
+      .catch(err => {
+        console.error(err)
+      })
+  }
+
   render() {
     if (this.state.loading) {
       return <Spinner />
@@ -251,15 +262,24 @@ class Editor extends React.Component {
               resetDefaultSettings={this.resetDefaultSettings}
             />
             <div className="buttons">
-              {this.props.tweet && this.state.online && (
-                <Button
-                  className="tweetButton"
-                  onClick={this.upload}
-                  title={this.state.uploading ? 'Loading...' : 'Tweet Image'}
-                  color="#57b5f9"
-                  style={{ marginRight: '8px' }}
-                />
-              )}
+              <Button
+                className="tweetButton"
+                onClick={() => this.format(this.state.code)}
+                title={this.state.formatLoading ? 'Formatting...' : 'P'}
+                color="#57b5f9"
+                style={{ marginRight: '8px' }}
+                disabled={this.state.code == null || this.state.code.length === 0}
+              />
+              {this.props.tweet &&
+                this.state.online && (
+                  <Button
+                    className="tweetButton"
+                    onClick={this.upload}
+                    title={this.state.uploading ? 'Loading...' : 'Tweet Image'}
+                    color="#57b5f9"
+                    style={{ marginRight: '8px' }}
+                  />
+                )}
               <Dropdown {...saveButtonOptions} onChange={this.save} />
             </div>
           </Toolbar>
@@ -304,15 +324,15 @@ class Editor extends React.Component {
 }
 
 function formatTimestamp() {
-  const timezoneOffset = (new Date()).getTimezoneOffset() * 60000
-  const timeString = (new Date(Date.now() - timezoneOffset)).toISOString()
+  const timezoneOffset = new Date().getTimezoneOffset() * 60000
+  const timeString = new Date(Date.now() - timezoneOffset)
+    .toISOString()
     .slice(0, 19)
-    .replace(/:/g,'-')
-    .replace('T','_')
+    .replace(/:/g, '-')
+    .replace('T', '_')
 
-  return timeString;
+  return timeString
 }
-
 
 function isImage(file) {
   return file.type.split('/')[0] === 'image'

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -216,12 +216,15 @@ class Editor extends React.Component {
     }
   }
 
-  format(code) {
-    try {
-      this.setState({ code: formatCode(code) })
-    } catch (err) {
-      //
-    }
+  format() {
+    this.setState(({ code }) => {
+      try {
+        const newCode = formatCode(code)
+        return { code: newCode }
+      } catch (e) {
+        // pass, create a toast here in the future.
+      }
+    })
   }
 
   render() {
@@ -261,10 +264,9 @@ class Editor extends React.Component {
             />
             <div className="buttons">
               <Button
-                className="tweetButton"
-                onClick={() => this.format(this.state.code)}
+                onClick={this.format}
                 title="Format"
-                color="#57b5f9"
+                color="white"
                 style={{ marginRight: '8px' }}
                 disabled={this.state.code == null || this.state.code.length === 0}
               />

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -265,7 +265,7 @@ class Editor extends React.Component {
               <Button
                 className="tweetButton"
                 onClick={() => this.format(this.state.code)}
-                title={this.state.formatLoading ? 'Formatting...' : 'P'}
+                title="Format"
                 color="#57b5f9"
                 style={{ marginRight: '8px' }}
                 disabled={this.state.code == null || this.state.code.length === 0}

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,7 +30,7 @@ import {
   DEFAULT_SETTINGS
 } from '../lib/constants'
 import { serializeState } from '../lib/routing'
-import { getState, formatCode } from '../lib/util'
+import { getState } from '../lib/util'
 
 const saveButtonOptions = {
   button: true,
@@ -62,7 +62,6 @@ class Editor extends React.Component {
     this.resetDefaultSettings = this.resetDefaultSettings.bind(this)
     this.getCarbonImage = this.getCarbonImage.bind(this)
     this.onDrop = this.onDrop.bind(this)
-    this.format = this.format.bind(this)
 
     this.setOffline = () => this.setState({ online: false })
     this.setOnline = () => this.setState({ online: true })
@@ -216,17 +215,6 @@ class Editor extends React.Component {
     }
   }
 
-  format() {
-    this.setState(({ code }) => {
-      try {
-        const newCode = formatCode(code)
-        return { code: newCode }
-      } catch (e) {
-        // pass, create a toast here in the future.
-      }
-    })
-  }
-
   render() {
     if (this.state.loading) {
       return <Spinner />
@@ -263,13 +251,6 @@ class Editor extends React.Component {
               resetDefaultSettings={this.resetDefaultSettings}
             />
             <div className="buttons">
-              <Button
-                onClick={this.format}
-                title="Format"
-                color="white"
-                style={{ marginRight: '8px' }}
-                disabled={this.state.code == null || this.state.code.length === 0}
-              />
               {this.props.tweet &&
                 this.state.online && (
                   <Button

--- a/components/Header.js
+++ b/components/Header.js
@@ -9,8 +9,8 @@ const Header = ({ enableHeroText }) => (
       </a>
       {enableHeroText ? (
         <h2 className="mt3">
-          Create and share beautiful images of your source code.<br /> Start typing or drop a file
-          into the text area to get started.
+          Create and share beautiful images of your source code.
+          <br /> Start typing or drop a file into the text area to get started.
         </h2>
       ) : null}
     </div>

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -36,7 +36,7 @@ export default () => {
         <meta name="og:image" content="/static/banner.png" />
         <meta name="theme-color" content="#121212" />
         <title>Carbon</title>
-        <link rel='manifest' href='/static/manifest.json' />
+        <link rel="manifest" href="/static/manifest.json" />
         <link rel="shortcut icon" href="/static/favicon.ico" />
         <link rel="stylesheet" href="/_next/static/style.css" />
         <link

--- a/components/Settings.js
+++ b/components/Settings.js
@@ -8,7 +8,9 @@ import Slider from './Slider'
 import Toggle from './Toggle'
 import WindowPointer from './WindowPointer'
 import Collapse from './Collapse'
+
 import { COLORS } from '../lib/constants'
+import { formatCode } from '../lib/util'
 
 class Settings extends React.Component {
   constructor(props) {
@@ -17,6 +19,7 @@ class Settings extends React.Component {
       isVisible: false
     }
     this.toggle = this.toggle.bind(this)
+    this.format = this.format.bind(this)
   }
 
   toggle() {
@@ -25,6 +28,15 @@ class Settings extends React.Component {
 
   handleClickOutside() {
     this.setState({ isVisible: false })
+  }
+
+  format() {
+    try {
+      const newCode = formatCode(this.props.code)
+      this.props.onChange('code', newCode)
+    } catch (e) {
+      // pass, create a toast here in the future.
+    }
   }
 
   render() {
@@ -123,8 +135,10 @@ class Settings extends React.Component {
               selected={this.props.exportSize || '2x'}
               onChange={this.props.onChange.bind(null, 'exportSize')}
             />
+            <Toggle label="Prettify code" center={true} enabled={false} onChange={this.format} />
             <Toggle
-              label="Reset settings"
+              label={<center className="red">Reset settings</center>}
+              center={true}
               enabled={false}
               onChange={this.props.resetDefaultSettings}
             />
@@ -185,6 +199,10 @@ class Settings extends React.Component {
             .settings-settings > :global(div):last-child,
             .settings-settings > :global(.collapse) {
               border-bottom: none;
+            }
+
+            .red {
+              color: red;
             }
           `}
         </style>

--- a/components/Slider.js
+++ b/components/Slider.js
@@ -13,7 +13,7 @@ export default class extends React.Component {
   render() {
     const minValue = this.props.minValue || 0
     const maxValue = this.props.maxValue || 100
-    const step = 'step' in this.props ? this.props.step : 1;
+    const step = 'step' in this.props ? this.props.step : 1
 
     return (
       <div className="slider">

--- a/handlers/image.js
+++ b/handlers/image.js
@@ -26,7 +26,8 @@ module.exports = browser => async (req, res) => {
         filter: n => {
           // %[00 -> 19] cause failures
           if (
-            n.innerText && n.innerText.match(/%\S\S/) &&
+            n.innerText &&
+            n.innerText.match(/%\S\S/) &&
             n.className &&
             n.className.startsWith('cm-') // is CodeMirror primitive string
           ) {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -52,9 +52,8 @@ const reverseMappings = mappings.map(mapping =>
 export const serializeState = state => {
   const stateString = encodeURIComponent(JSON.stringify(state))
 
-  return encodeURIComponent(typeof window !== 'undefined'
-    ? btoa(stateString)
-    : Buffer.from(stateString).toString('base64')
+  return encodeURIComponent(
+    typeof window !== 'undefined' ? btoa(stateString) : Buffer.from(stateString).toString('base64')
   )
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,4 +1,6 @@
 import morph from 'morphmorph'
+import prettier from 'prettier/standalone'
+import babylonParser from 'prettier/parser-babylon'
 
 const KEY = 'CARBON_STATE'
 
@@ -39,4 +41,17 @@ export const fileToDataURL = blob =>
     const reader = new FileReader()
     reader.onload = e => res(e.target.result)
     reader.readAsDataURL(blob)
+  })
+
+export const formatCode = code =>
+  new Promise((resolve, reject) => {
+    try {
+      const formatted = prettier.format(code, {
+        parser: 'babylon',
+        plugins: [babylonParser]
+      })
+      resolve(formatted)
+    } catch (err) {
+      reject(err)
+    }
   })

--- a/lib/util.js
+++ b/lib/util.js
@@ -46,5 +46,7 @@ export const fileToDataURL = blob =>
 export const formatCode = code =>
   prettier.format(code, {
     parser: 'babylon',
-    plugins: [babylonParser]
+    plugins: [babylonParser],
+    semi: false,
+    singleQuote: true,
   })

--- a/lib/util.js
+++ b/lib/util.js
@@ -44,14 +44,7 @@ export const fileToDataURL = blob =>
   })
 
 export const formatCode = code =>
-  new Promise((resolve, reject) => {
-    try {
-      const formatted = prettier.format(code, {
-        parser: 'babylon',
-        plugins: [babylonParser]
-      })
-      resolve(formatted)
-    } catch (err) {
-      reject(err)
-    }
+  prettier.format(code, {
+    parser: 'babylon',
+    plugins: [babylonParser]
   })

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,5 +48,5 @@ export const formatCode = code =>
     parser: 'babylon',
     plugins: [babylonParser],
     semi: false,
-    singleQuote: true,
+    singleQuote: true
   })


### PR DESCRIPTION
<!---   Provide a general summary of your changes in the Title above
        Expand on it in the description below (if applicable)    -->
<!-- Attach a screenshot where applicable -->

Following the discussion issue on https://github.com/dawnlabs/carbon/issues/443

## Description
<!--- Describe your changes -->

For now it's only a naive simple formatCode using prettier's standalone package. It only uses Babylon parser.

Plan for changes:

* Smart parser switch: If the language is *auto* it should use babylon as default parser. Based on the supported list of languages built-in to the prettier and the detected language on Carbon, it should switch the parser if required.

* Showing an alert/toast in case format can't be done (prettier can be tricky sometimes)

* Adding prettier's options available in the settings dropdown

* Do the formatting in a web worker in case the code is a bit long.

@mfix22 @briandennis 