### PR TITLE
Split F# and OCaml entries

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -219,7 +219,7 @@ export const LANGUAGES = [
     mode: 'fortran'
   },
   {
-    name: 'F# / OCaml',
+    name: 'F#',
     mode: 'mllike'
   },
   {
@@ -327,6 +327,10 @@ export const LANGUAGES = [
     mode: 'clike',
     mime: 'text/x-objectivec',
     short: 'objectivec'
+  },
+  {
+    name: 'OCaml',
+    mode: 'mllike'
   },
   {
     name: 'Pascal',


### PR DESCRIPTION
While they use the same mode, OCaml is easy to miss.

## Description

I split the entries so that there is a F# entry and an OCaml entry.

Thanks! :sparkles: 