### PR TITLE
Remove gDSFP in Carbon

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -28,7 +28,7 @@ class Carbon extends PureComponent {
     super(props)
 
     this.state = {
-      language: props.config.language
+      ...handleLanguageChange(this.props.children, this.props)
     }
 
     this.handleTitleBarChange = this.handleTitleBarChange.bind(this)
@@ -38,17 +38,11 @@ class Carbon extends PureComponent {
   }
 
   componentDidMount() {
-    this.setState(handleLanguageChange(this.props.children, this.props))
-
     const ro = new ResizeObserver(entries => {
       const cr = entries[0].contentRect
       this.props.onAspectRatioChange(cr.width / cr.height)
     })
     ro.observe(this.exportContainerNode)
-  }
-
-  static getDerivedStateFromProps(newProps) {
-    return handleLanguageChange(newProps.children, newProps) || null
   }
 
   codeUpdated(newCode) {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -311,6 +311,7 @@ class Editor extends React.Component {
                 isOver={isOver || canDrop}
                 title={`Drop your file here to import ${isOver ? '✋' : '✊'}`}
               >
+                {/*key ensures Carbon's internal language state is updated when it's changed by Dropdown*/}
                 <Carbon
                   key={this.state.language}
                   config={this.state}

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -312,6 +312,7 @@ class Editor extends React.Component {
                 title={`Drop your file here to import ${isOver ? '✋' : '✊'}`}
               >
                 <Carbon
+                  key={this.state.language}
                   config={this.state}
                   updateCode={this.updateCode}
                   onAspectRatioChange={this.updateAspectRatio}


### PR DESCRIPTION
Carbon still manages internal language state, but will get reconstructed when parent's language state changes. 