### PR TITLE
Don't use custom history API

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -6,6 +6,7 @@ import { DragDropContext } from 'react-dnd'
 import domtoimage from 'dom-to-image'
 import ReadFileDropContainer, { DATA_URL, TEXT } from 'dropperx'
 import Spinner from 'react-spinner'
+import shallowEquals from '../lib/shallow-equals'
 
 // Ours
 import Button from './Button'
@@ -113,8 +114,10 @@ class Editor extends React.Component {
     window.removeEventListener('online', this.setOnline)
   }
 
-  componentDidUpdate() {
-    this.props.onUpdate(this.state)
+  componentDidUpdate(prevProps, prevState) {
+    if(!shallowEquals(this.state, prevState)) {
+      this.props.onUpdate(this.state)
+    }
   }
 
   getCarbonImage({ format, type } = { format: 'png' }) {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -80,11 +80,6 @@ export const updateQueryString = (router, state) => {
   const mappedState = mapper.map(reverseMappings, state)
   serializeCode(mappedState)
 
-  const urlObj = {
-    pathname: router.pathname,
-    query: mappedState
-  }
-
   router.replace({
     pathname: router.pathname
   }, {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -1,12 +1,5 @@
 import Morph from 'morphmorph'
 
-let createHistory
-let history
-if (typeof window !== 'undefined') {
-  createHistory = require('history').createBrowserHistory
-  history = createHistory()
-}
-
 const mapper = new Morph({
   types: {
     bool: v => {
@@ -68,11 +61,6 @@ export const deserializeState = serializedState => {
   return JSON.parse(decodeURIComponent(stateString))
 }
 
-const keysToQuery = keys =>
-  `?${Object.keys(keys)
-    .map(key => `${key}=${keys[key]}`)
-    .join('&')}`
-
 export const getQueryStringState = query => {
   if (query.state) {
     return deserializeState(query.state)
@@ -88,15 +76,21 @@ export const getQueryStringState = query => {
   return state
 }
 
-export const updateQueryString = state => {
-  if (history.location.search.indexOf('react_perf') < 0) {
-    const mappedState = mapper.map(reverseMappings, state)
-    serializeCode(mappedState)
+export const updateQueryString = (router, state) => {
+  const mappedState = mapper.map(reverseMappings, state)
+  serializeCode(mappedState)
 
-    history.replace({
-      search: encodeURI(keysToQuery(mappedState))
-    })
+  const urlObj = {
+    pathname: router.pathname,
+    query: mappedState
   }
+
+  router.replace({
+    pathname: router.pathname
+  }, {
+    pathname: router.pathname,
+    query: mappedState
+  }, {shallow: true})
 }
 
 // private

--- a/lib/shallow-equals.js
+++ b/lib/shallow-equals.js
@@ -1,0 +1,25 @@
+export default function shallowEquals (a, b) {
+  for (const i in a) {
+    // NaN === NaN is false in Javascript
+    if(isNaN(b[i]) && isNaN(a[i])) {
+      continue
+    }
+    if (b[i] !== a[i]) {
+      console.log('DID NOT MATCH', i, a[i], b[i])
+      return false
+    }
+  }
+
+  for (const i in b) {
+    // NaN === NaN is false in Javascript
+    if(isNaN(b[i]) && isNaN(a[i])) {
+      continue
+    }
+
+    if (b[i] !== a[i]) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,16 +11,17 @@ import { saveState } from '../lib/util'
 
 class Index extends React.Component {
   render() {
+    const {router} = this.props
     return (
       <Page enableHeroText={true}>
-        <Editor {...this.props.router} onUpdate={onEditorUpdate} api={api} />
+        <Editor {...router} onUpdate={(state) => onEditorUpdate(router, state)} api={api} />
       </Page>
     )
   }
 }
 
-function onEditorUpdate(state) {
-  updateQueryString(state)
+function onEditorUpdate(router, state) {
+  updateQueryString(router, state)
   const s = { ...state }
   delete s.code
   delete s.backgroundImage


### PR DESCRIPTION
Fixes https://github.com/zeit/next.js/issues/4994

`componentDidUpdate` is called for both props + state changes, `onEditorChange` only has to be called when the state is changed, so I added a shallow equals check to make sure it's only updated when the state really has been changed.

This solves the back button issue by removing the custom history API being used. Next.js needs to control the history as it puts some `state` into the history entry for when you're using the back button. Hence why you saw the error.