### PR TITLE
Updated link to "Adding themes/languages" note

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Is your issue for a new theme or language? As of Carbon `3.0.0`, the core Carbon team is no 
 longer implementing new themes or languages ourselves, but we are happy to accept PRs to add new ones.
 
-Please see https://github.com/dawnlabs/carbon#a-note-on-adding-themeslanguages for notes on how to do so 😄 
+Please see https://github.com/dawnlabs/carbon/blob/master/.github/CONTRIBUTING.md#a-note-on-adding-themeslanguages for notes on how to do so 😄 
 -->
 <!-- Attach a screenshot where applicable -->
 ### Expected Behavior

--- a/.github/tonic.yml
+++ b/.github/tonic.yml
@@ -14,4 +14,4 @@ labelConfig:
     comment: |
       This issue has been marked "$LABEL" and will be closed in $CLOSE_TIME. As of Carbon `3.0.0`, the Carbon core team is no longer implementing new themes or languages (although the ability to create your own will be implemented soon!). However, PRs to add new ones will be happily accepted.
       
-      Please see https://github.com/dawnlabs/carbon#a-note-on-adding-themeslanguages for notes on how to do so 👌. 
+      Please see https://github.com/dawnlabs/carbon/blob/master/.github/CONTRIBUTING.md#a-note-on-adding-themeslanguages for notes on how to do so 👌. 


### PR DESCRIPTION
Updated the link pointing to the "Adding themes/languages" note:

```diff
- https://github.com/dawnlabs/carbon#a-note-on-adding-themeslanguages
+ https://github.com/dawnlabs/carbon/blob/master/.github/CONTRIBUTING.md#a-note-on-adding-themeslanguages
```