### PR TITLE
Increase dropdown border width

### DIFF
--- a/components/Dropdown.js
+++ b/components/Dropdown.js
@@ -174,6 +174,7 @@ const SelectedItem = ({ getToggleButtonProps, getInputProps, children, isOpen, c
 
           .dropdown-display.is-open {
             border-radius: 3px 3px 0 0;
+            border-width: 2px;
           }
 
           .dropdown-display-text {
@@ -201,8 +202,8 @@ const ListItems = ({ children, color }) => {
       <style jsx>
         {`
           .dropdown-list {
-            margin-top: -1px;
-            border: 1px solid ${color || COLORS.SECONDARY};
+            margin-top: -2px;
+            border: 2px solid ${color || COLORS.SECONDARY};
             border-radius: 0 0 3px 3px;
             max-height: 350px;
             overflow-y: scroll;


### PR DESCRIPTION
<img width="414" alt="syntax-border" src="https://user-images.githubusercontent.com/3892149/48724979-c2f43080-ebf8-11e8-992c-9735bd19c25d.png">

## Description
Increased the border-width to 2px on the dropdown and dropdown button when it's selected. Based on @jakedex new design.