### PR TITLE
Adds CLI hooks (IDs) to certain elements

### DIFF
--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -242,7 +242,7 @@ class Carbon extends React.PureComponent {
 
     return (
       <div className="section">
-        <div className="export-container" ref={this.getRef} id="export-area">
+        <div className="export-container" ref={this.getRef} id="export-container">
           {content}
           <div className="twitter-png-fix" />
         </div>

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -242,7 +242,7 @@ class Carbon extends React.PureComponent {
 
     return (
       <div className="section">
-        <div className="export-container" ref={this.getRef}>
+        <div className="export-container" ref={this.getRef} id="export-area">
           {content}
           <div className="twitter-png-fix" />
         </div>

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -37,7 +37,7 @@ class ExportMenu extends React.PureComponent {
     const { isVisible } = this.state
 
     return (
-      <div className="export-container" id="export-initializer">
+      <div className="export-container" id="export-menu">
         <Button
           selected={isVisible}
           className="exportButton"
@@ -85,10 +85,10 @@ class ExportMenu extends React.PureComponent {
             <div className="save-container">
               <span>Save as</span>
               <div>
-                <button onClick={this.handleExport('png')} className="save-button" id="png-export">
+                <button onClick={this.handleExport('png')} className="save-button" id="export-png">
                   PNG
                 </button>
-                <button onClick={this.handleExport('svg')} className="save-button" id="svg-export">
+                <button onClick={this.handleExport('svg')} className="save-button" id="export-svg">
                   SVG
                 </button>
               </div>

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -37,7 +37,7 @@ class ExportMenu extends React.PureComponent {
     const { isVisible } = this.state
 
     return (
-      <div className="export-container">
+      <div className="export-container" id="export-initializer">
         <Button
           selected={isVisible}
           className="exportButton"
@@ -85,10 +85,10 @@ class ExportMenu extends React.PureComponent {
             <div className="save-container">
               <span>Save as</span>
               <div>
-                <button onClick={this.handleExport('png')} className="save-button">
+                <button onClick={this.handleExport('png')} className="save-button" id="png-export">
                   PNG
                 </button>
-                <button onClick={this.handleExport('svg')} className="save-button">
+                <button onClick={this.handleExport('svg')} className="save-button" id="svg-export">
                   SVG
                 </button>
               </div>


### PR DESCRIPTION
Hi guys. :) `v3.6.0` introduced [some breaking changes to the CLI](https://github.com/mixn/carbon-now-cli/issues/39) I’m maintaining and trying to keep in sync (feature-wise).

I texted @mfix22 on Twitter about maybe adding some (non-changing) hooks for the CLI, so this doesn’t happen in the future any more. :)

I hereby added four `id`s for all the things the CLI accesses. Let me know if any changes are needed (maybe namespacing?)… :)

Thanks for being so responsive about this, hope to patch the CLI as soon as this is merged and deployed. :)

🙏 