### PR TITLE
Caution about the use of images in a post

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Once you've got all of your code into Carbon, you can customize your image by ch
 
 After you've customized your image you can either Tweet a link to the image, or save it directly.
 
+If you use the &apos;Tweet&apos; button, Carbon will automatically make your image accessible. However, if you want to manually tweet your carbon image, please check out [how to make your Twitter images accessible](https://help.twitter.com/en/using-twitter/picture-descriptions).
+
+If you include a carbon image in a post, the source code will be invisible for assistive technology, it will not be possible to enlarge it or copy it, etc. Please, think about adding another element with the source code as text. For example, you can add [a HTML Details Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) below the image.
+
 ## Community
 Check out these projects our awesome community has created:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ After you've customized your image you can either Tweet a link to the image, or 
 
 If you use the &apos;Tweet&apos; button, Carbon will automatically make your image accessible. However, if you want to manually tweet your carbon image, please check out [how to make your Twitter images accessible](https://help.twitter.com/en/using-twitter/picture-descriptions).
 
-If you include a carbon image in a post, the source code will be invisible for assistive technology, it will not be possible to enlarge it or copy it, etc. Please, think about adding another element with the source code as text. For example, you can add [a HTML Details Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) below the image.
+If you include a Carbon image in a post, the source code will be invisible for assistive technology, it will not be possible to enlarge it or copy it, etc. Please, think about adding another element with the source code as text, like an [HTML Details Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) below the image.
 
 ## Community
 Check out these projects our awesome community has created:

--- a/pages/about.js
+++ b/pages/about.js
@@ -54,8 +54,8 @@ export default () => (
           ).
         </p>
         <p className="mt2 mb3">
-          If you include a Carbon image in a post, the source code will be invisible for assistive
-          technology, it will not be possible to enlarge it or copy it, etc. Please, think about
+          If you include a Carbon image in a post, the source code will be invisible to assistive
+          technology — it will not be possible to enlarge or copy it, etc. Please, think about
           adding another element with the source code as text, like (
           <a
             className="link"

--- a/pages/about.js
+++ b/pages/about.js
@@ -54,14 +54,14 @@ export default () => (
           ).
         </p>
         <p className="mt2 mb3">
-          If you include a carbon image in a post, the source code will be invisible for assistive
+          If you include a Carbon image in a post, the source code will be invisible for assistive
           technology, it will not be possible to enlarge it or copy it, etc. Please, think about
-          adding another element with the source code as text. For example, you can add (
+          adding another element with the source code as text, like (
           <a
             className="link"
             href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
           >
-            a HTML Details Element
+            an HTML Details Element
           </a>
           ) below the image.
         </p>

--- a/pages/about.js
+++ b/pages/about.js
@@ -47,11 +47,23 @@ export default () => (
         </p>
         <p className="mt2 mb3">
           If you use the &apos;Tweet&apos; button, Carbon will automatically make your image
-          accessible. However, if you want to manually tweet your carbon image, please check out{' '}
+          accessible. However, if you want to manually tweet your carbon image, please check out (
           <a className="link" href="https://help.twitter.com/en/using-twitter/picture-descriptions">
-            this page
-          </a>{' '}
-          to found out how to make your Twitter images accessible.
+            how to make your Twitter images accessible
+          </a>
+          ).
+        </p>
+        <p className="mt2 mb3">
+          If you include a carbon image in a post, the source code will be invisible for assistive
+          technology, it will not be possible to enlarge it or copy it, etc. Please, think about
+          adding another element with the source code as text. For example, you can add (
+          <a
+            className="link"
+            href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details"
+          >
+            a HTML Details Element
+          </a>
+          ) below the image.
         </p>
       </div>
       <div>


### PR DESCRIPTION
## Description
* Adding more information in About page about the use of images with source code. This warning is motivated after talking to Juanjo Montiel, a blind developer, who finds it impossible to read the source code if it's within images. Furthermore, there are other visual disabilities for which text within images cannot be enlarged correctly. On the other hand, the source code cannot be copied. I find it interesting to raise awareness of it.
* Updating the section `Export/Sharing` in README.md with the same information.