### PR TITLE
feat: expose updateCode method for headless browser

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -59,6 +59,13 @@ class Editor extends React.Component {
     this.onDrop = this.onDrop.bind(this)
 
     this.innerRef = node => (this.carbonNode = node)
+    
+    // expose updateCode method
+    // why expose this?
+    // eg. for headless browser to generate image
+    if (typeof window !== "undefined") {
+      window.updateCode = this.updateCode.bind(this)
+    }
   }
 
   async componentDidMount() {


### PR DESCRIPTION
### why expose this?

Third-party jumps to `https://carbon.now.sh` will be restricted due to URL restrictions.

Unable to generate more code

So another idea is to use the headless browser to open `https://carbon.now.sh`, paste the code, and then generate a screenshot

So we need to expose a method that can change the code in `codemirror`

<!---   Provide a general summary of your changes in the Title above
        Expand on it in the description below (if applicable)    -->
<!-- Attach a screenshot where applicable -->

## Description
<!--- Describe your changes -->