### PR TITLE
Fix Medium embedding workflow

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -63,8 +63,7 @@ class Editor extends React.Component {
   async componentDidMount() {
     const { asPath = '' } = this.props.router
     const { query } = url.parse(decode(asPath), true)
-    const queryParams = getQueryStringState(query)
-    const initialState = Object.keys(queryParams).length ? queryParams : {}
+    const initialState = getQueryStringState(query)
 
     const newState = {
       // Load from localStorage

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,7 +30,7 @@ import {
   DEFAULT_PRESET_ID
 } from '../lib/constants'
 import { serializeState, getQueryStringState } from '../lib/routing'
-import { getSettings, unescapeHtml, formatCode, omit, decode } from '../lib/util'
+import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
 import LanguageIcon from './svg/Language'
 
 const languageIcon = <LanguageIcon />
@@ -62,7 +62,7 @@ class Editor extends React.Component {
 
   async componentDidMount() {
     const { asPath = '' } = this.props.router
-    const { query } = url.parse(decode(asPath), true)
+    const { query } = url.parse(asPath, true)
     const initialState = getQueryStringState(query)
 
     const newState = {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,7 +30,7 @@ import {
   DEFAULT_PRESET_ID
 } from '../lib/constants'
 import { serializeState, getQueryStringState } from '../lib/routing'
-import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
+import { getSettings, unescapeHtml, formatCode, omit, decode } from '../lib/util'
 import LanguageIcon from './svg/Language'
 
 const languageIcon = <LanguageIcon />
@@ -62,7 +62,7 @@ class Editor extends React.Component {
 
   async componentDidMount() {
     const { asPath = '' } = this.props.router
-    const { query } = url.parse(asPath, true)
+    const { query } = url.parse(decode(asPath), true)
     const queryParams = getQueryStringState(query)
     const initialState = Object.keys(queryParams).length ? queryParams : {}
 

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -7,8 +7,6 @@ import Button from './Button'
 import Input from './Input'
 import Popout, { managePopout } from './Popout'
 
-import { decode } from '../lib/util'
-
 const toIFrame = url =>
   `<iframe
   src="https://carbon.now.sh/embed${url}"
@@ -25,7 +23,7 @@ function verifyPayloadSize(str) {
 }
 
 const CopyEmbed = withRouter(({ router: { asPath } }) => {
-  const text = React.useMemo(() => toIFrame(decode(asPath)), [asPath])
+  const text = React.useMemo(() => toIFrame(asPath), [asPath])
   const { onClick, copied } = useCopyTextHandler(text)
 
   return (

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -15,6 +15,8 @@ const toIFrame = url =>
 </iframe>
 `
 
+const toURL = url => encodeURI(`https://carbon.now.sh/embed${url}`)
+
 const MAX_PAYLOAD_SIZE = 5e6 // bytes
 function verifyPayloadSize(str) {
   if (typeof str !== 'string') return true
@@ -22,13 +24,20 @@ function verifyPayloadSize(str) {
   return new Blob([str]).size < MAX_PAYLOAD_SIZE
 }
 
-const CopyEmbed = withRouter(({ router: { asPath } }) => {
-  const text = React.useMemo(() => toIFrame(asPath), [asPath])
+const CopyEmbed = withRouter(({ router: { asPath }, mapper, title, margin }) => {
+  const text = React.useMemo(() => mapper(asPath), [mapper, asPath])
   const { onClick, copied } = useCopyTextHandler(text)
 
   return (
-    <Button onClick={onClick} center color={COLORS.PURPLE} padding="12px 16px" flex="1 0 68px">
-      {copied ? 'Copied!' : 'Copy Embed'}
+    <Button
+      onClick={onClick}
+      center
+      hoverColor={COLORS.PURPLE}
+      color={COLORS.DARK_PURPLE}
+      margin={margin}
+      style={{ minWidth: 48 }}
+    >
+      {copied ? 'Copied!' : title}
     </Button>
   )
 })
@@ -98,7 +107,13 @@ class ExportMenu extends React.PureComponent {
             <Button center color={COLORS.PURPLE} onClick={this.handleExport('open')}>
               Open
             </Button>
-            <CopyEmbed />
+            <div className="save-container">
+              <span>Copy embed</span>
+              <div>
+                <CopyEmbed title="URL" mapper={toURL} margin="0 4px 0 0" />
+                <CopyEmbed title="IFrame" mapper={toIFrame} margin="0 0 0 4px" />
+              </div>
+            </div>
             <div className="save-container">
               <span>Save as</span>
               <div>
@@ -170,6 +185,11 @@ class ExportMenu extends React.PureComponent {
               margin-top: 6px;
               display: flex;
               flex: 1;
+            }
+
+            .save-container:first-of-type {
+              padding: 12px 12px;
+              border-right: 1px solid ${COLORS.PURPLE};
             }
           `}
         </style>

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -7,6 +7,8 @@ import Button from './Button'
 import Input from './Input'
 import Popout, { managePopout } from './Popout'
 
+import { decode } from '../lib/util'
+
 const toIFrame = url =>
   `<iframe
   src="https://carbon.now.sh/embed${url}"
@@ -25,7 +27,7 @@ function verifyPayloadSize(str) {
 const CopyEmbed = withRouter(
   React.memo(
     ({ router: { asPath } }) => {
-      const { onClick, copied } = useCopyTextHandler(toIFrame(asPath))
+      const { onClick, copied } = useCopyTextHandler(toIFrame(decode(asPath)))
 
       return (
         <Button onClick={onClick} center color={COLORS.PURPLE} padding="12px 16px" flex="1 0 68px">

--- a/components/ExportMenu.js
+++ b/components/ExportMenu.js
@@ -24,20 +24,16 @@ function verifyPayloadSize(str) {
   return new Blob([str]).size < MAX_PAYLOAD_SIZE
 }
 
-const CopyEmbed = withRouter(
-  React.memo(
-    ({ router: { asPath } }) => {
-      const { onClick, copied } = useCopyTextHandler(toIFrame(decode(asPath)))
+const CopyEmbed = withRouter(({ router: { asPath } }) => {
+  const text = React.useMemo(() => toIFrame(decode(asPath)), [asPath])
+  const { onClick, copied } = useCopyTextHandler(text)
 
-      return (
-        <Button onClick={onClick} center color={COLORS.PURPLE} padding="12px 16px" flex="1 0 68px">
-          {copied ? 'Copied!' : 'Copy Embed'}
-        </Button>
-      )
-    },
-    (prevProps, nextProps) => prevProps.router.asPath === nextProps.router.asPath
+  return (
+    <Button onClick={onClick} center color={COLORS.PURPLE} padding="12px 16px" flex="1 0 68px">
+      {copied ? 'Copied!' : 'Copy Embed'}
+    </Button>
   )
-)
+})
 
 const popoutStyle = { width: '280px', right: 0 }
 

--- a/components/GistContainer.js
+++ b/components/GistContainer.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import url from 'url'
 import { withRouter } from 'next/router'
 
 import { escapeHtml } from '../lib/util'
@@ -9,8 +8,7 @@ class GistContainer extends React.Component {
   static contextType = ApiContext
 
   async componentDidMount() {
-    const { asPath = '' } = this.props.router
-    const { pathname } = url.parse(asPath, true)
+    const { pathname } = this.props.router
     const path = escapeHtml(pathname.split('/').pop())
     let newState = {}
 

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -63,7 +63,7 @@ export const deserializeState = serializedState => {
   return JSON.parse(decodeURIComponent(stateString))
 }
 
-export const getQueryStringState = query => {
+const getQueryStringObject = query => {
   if (query.state) {
     return deserializeState(query.state)
   }
@@ -76,6 +76,11 @@ export const getQueryStringState = query => {
   })
 
   return state
+}
+
+export const getQueryStringState = query => {
+  const queryParams = getQueryStringObject(query)
+  return Object.keys(queryParams).length ? queryParams : {}
 }
 
 export const updateQueryString = (router, state) => {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -1,5 +1,4 @@
 import Morph from 'morphmorph'
-import qs from 'querystring'
 
 const mapper = new Morph({
   types: {
@@ -85,17 +84,29 @@ export const getQueryStringState = query => {
 
 export const updateQueryString = (router, state) => {
   const mappedState = mapper.map(reverseMappings, state)
+  serializeCode(mappedState)
   // calls `encodeURIComponent` on each key internally
-  const query = qs.stringify(mappedState)
+  // const query = qs.stringify(mappedState)
 
   router.replace(
     {
       pathname: router.pathname
     },
-    // `encodeURI` prevents issues when pasting browser URL directly to sites like Medium
-    encodeURI(`${router.pathname}?${query}`),
+    {
+      pathname: router.pathname,
+      query: mappedState
+    },
     { shallow: true }
   )
+}
+
+// private
+function serializeCode(state) {
+  try {
+    if (state.code) state.code = encodeURIComponent(state.code)
+  } catch (e) {
+    // encoding errors should not crash the app
+  }
 }
 
 function deserializeCode(state) {

--- a/lib/routing.js
+++ b/lib/routing.js
@@ -1,4 +1,5 @@
 import Morph from 'morphmorph'
+import qs from 'querystring'
 
 const mapper = new Morph({
   types: {
@@ -79,27 +80,17 @@ export const getQueryStringState = query => {
 
 export const updateQueryString = (router, state) => {
   const mappedState = mapper.map(reverseMappings, state)
-  serializeCode(mappedState)
+  // calls `encodeURIComponent` on each key internally
+  const query = qs.stringify(mappedState)
 
   router.replace(
     {
       pathname: router.pathname
     },
-    {
-      pathname: router.pathname,
-      query: mappedState
-    },
+    // `encodeURI` prevents issues when pasting browser URL directly to sites like Medium
+    encodeURI(`${router.pathname}?${query}`),
     { shallow: true }
   )
-}
-
-// private
-function serializeCode(state) {
-  try {
-    if (state.code) state.code = encodeURIComponent(state.code)
-  } catch (e) {
-    // encoding errors should not crash the app
-  }
 }
 
 function deserializeCode(state) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -90,11 +90,3 @@ export const generateId = () =>
   Math.random()
     .toString(36)
     .slice(2)
-
-export const decode = str => {
-  try {
-    return decodeURI(str)
-  } catch (error) {
-    return str
-  }
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -90,3 +90,11 @@ export const generateId = () =>
   Math.random()
     .toString(36)
     .slice(2)
+
+export const decode = str => {
+  try {
+    return decodeURI(str)
+  } catch (error) {
+    return str
+  }
+}

--- a/pages/embed.js
+++ b/pages/embed.js
@@ -57,16 +57,15 @@ class Embed extends React.Component {
   handleUpdate = updates => {
     const { asPath = '' } = this.props.router
     const { query } = url.parse(decode(asPath), true)
-    const queryParams = getQueryStringState(query)
-    const initialState = Object.keys(queryParams).length ? queryParams : {}
+    const initialState = getQueryStringState(query)
 
     this.setState(
       {
         ...initialState,
         ...updates,
         id: query.id,
-        copyable: queryParams.copy !== false,
-        readOnly: queryParams.readonly !== false,
+        copyable: initialState.copy !== false,
+        readOnly: initialState.readonly !== false,
         mounted: true
       },
       this.postMessage

--- a/pages/embed.js
+++ b/pages/embed.js
@@ -11,6 +11,7 @@ import Carbon from '../components/Carbon'
 import GistContainer from '../components/GistContainer'
 import { DEFAULT_CODE, DEFAULT_SETTINGS } from '../lib/constants'
 import { getQueryStringState } from '../lib/routing'
+import { decode } from '../lib/util'
 
 const isInIFrame = morph.get('parent.window.parent')
 const getParent = win => {
@@ -55,7 +56,7 @@ class Embed extends React.Component {
 
   handleUpdate = updates => {
     const { asPath = '' } = this.props.router
-    const { query } = url.parse(asPath, true)
+    const { query } = url.parse(decode(asPath), true)
     const queryParams = getQueryStringState(query)
     const initialState = Object.keys(queryParams).length ? queryParams : {}
 

--- a/pages/embed.js
+++ b/pages/embed.js
@@ -11,7 +11,6 @@ import Carbon from '../components/Carbon'
 import GistContainer from '../components/GistContainer'
 import { DEFAULT_CODE, DEFAULT_SETTINGS } from '../lib/constants'
 import { getQueryStringState } from '../lib/routing'
-import { decode } from '../lib/util'
 
 const isInIFrame = morph.get('parent.window.parent')
 const getParent = win => {
@@ -56,7 +55,7 @@ class Embed extends React.Component {
 
   handleUpdate = updates => {
     const { asPath = '' } = this.props.router
-    const { query } = url.parse(decode(asPath), true)
+    const { query } = url.parse(asPath, true)
     const initialState = getQueryStringState(query)
 
     this.setState(


### PR DESCRIPTION
This encodes the entire URI before writing to `window.location`, requiring that we then decode it when reading from the router. 

Closes https://github.com/dawnlabs/carbon/issues/705