### PR TITLE
nef - integration with Carbon

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Check out these projects our awesome community has created:
 - [CLI `carbon-now-cli`](https://github.com/mixn/carbon-now-cli) - Open a file in Carbon or download it directly using `carbon-now`, featuring an interactive mode, selective highlighting and more
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
+- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`.
 
 ##### Libraries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Check out these projects our awesome community has created:
 - [CLI `carbon-now-cli`](https://github.com/mixn/carbon-now-cli) - Open a file in Carbon or download it directly using `carbon-now`, featuring an interactive mode, selective highlighting and more
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
-- [`nef`](https://github.com/bow-swift/nef) - Export multiple Carbon code snippets for any `Xcode Playground`.
+- [`nef`](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets) - Export multiple Carbon code snippets from `Xcode Playground`.
 
 ##### Libraries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Check out these projects our awesome community has created:
 - [CLI `carbon-now-cli`](https://github.com/mixn/carbon-now-cli) - Open a file in Carbon or download it directly using `carbon-now`, featuring an interactive mode, selective highlighting and more
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
-- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`. Just open your [Xcode Playground](https://github.com/bow-swift/nef#-creating-a-xcode-playground), write several pieces of code and export all of them using [nef](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets)
+- [`nef`](https://github.com/bow-swift/nef) - Export multiple Carbon code snippets for any `Xcode Playground`.
 
 ##### Libraries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Check out these projects our awesome community has created:
 - [CLI `carbon-now-cli`](https://github.com/mixn/carbon-now-cli) - Open a file in Carbon or download it directly using `carbon-now`, featuring an interactive mode, selective highlighting and more
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
-- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`.
+- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`. Just open your Xcode Playground, write several pieces of code and export all of them using [nef](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets)
 
 ##### Libraries
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Check out these projects our awesome community has created:
 - [CLI `carbon-now-cli`](https://github.com/mixn/carbon-now-cli) - Open a file in Carbon or download it directly using `carbon-now`, featuring an interactive mode, selective highlighting and more
 - [Carbonize](https://itunes.apple.com/us/app/carbonize/id1451177988) - A macOS wrapper with extended native features
 - [CodeExpander](https://codeexpander.com) - A smart GitHub gist client with the TextExpander features
-- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`. Just open your Xcode Playground, write several pieces of code and export all of them using [nef](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets)
+- [`nef`](https://github.com/bow-swift/nef) - Export Carbon code snippets for given `Xcode Playgrounds`. Just open your [Xcode Playground](https://github.com/bow-swift/nef#-creating-a-xcode-playground), write several pieces of code and export all of them using [nef](https://github.com/bow-swift/nef#-exporting-carbon-code-snippets)
 
 ##### Libraries
 


### PR DESCRIPTION
## Description
We've added an integration with Carbon in our tool `nef` - you can read more about it [here](https://nef.bow-swift.io/docs/tutorials/first-steps-with-carbon/)

## What is nef?
In a general way, `nef` is a CLI that lets you have compile-time verification of your documentation written as **Xcode Playground**. Now, from version [0.3.0](https://www.47deg.com/blog/nef-0-3-0-release/#carbon-integration-2) we have integrated Carbon, so you can write in **official Apple playgrounds**, and export the whole snippets with just one command.

## Request
We love Carbon, and we usually use it; this is the reason for this integration and the request for adding in the Carbon's tool list.


