### PR TITLE
Added SynthWave '84 theme + Text Shadows

### DIFF
--- a/components/Meta.js
+++ b/components/Meta.js
@@ -6,7 +6,7 @@ import Font from './style/Font'
 import Typography from './style/Typography'
 
 const HIGHLIGHTS_ONLY = ['shades-of-purple', 'vscode']
-const LOCAL_STYLESHEETS = ['one-light', 'one-dark', 'verminal', 'night-owl', 'nord']
+const LOCAL_STYLESHEETS = ['one-light', 'one-dark', 'verminal', 'night-owl', 'nord', 'synthWave-84']
 const CDN_STYLESHEETS = THEMES.filter(
   t => LOCAL_STYLESHEETS.indexOf(t.id) < 0 && HIGHLIGHTS_ONLY.indexOf(t.id) < 0
 )

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -6,7 +6,7 @@ import Font from './style/Font'
 import Typography from './style/Typography'
 
 const HIGHLIGHTS_ONLY = ['shades-of-purple', 'vscode']
-const LOCAL_STYLESHEETS = ['one-light', 'one-dark', 'verminal', 'night-owl', 'nord', 'synthWave-84']
+const LOCAL_STYLESHEETS = ['one-light', 'one-dark', 'verminal', 'night-owl', 'nord', 'synthwave-84']
 const CDN_STYLESHEETS = THEMES.filter(
   t => LOCAL_STYLESHEETS.indexOf(t.id) < 0 && HIGHLIGHTS_ONLY.indexOf(t.id) < 0
 )

--- a/components/Themes/index.js
+++ b/components/Themes/index.js
@@ -89,6 +89,7 @@ class Themes extends React.PureComponent {
     const { themes, theme, isVisible, toggleVisibility } = this.props
 
     const highlights = { ...theme.highlights, ...this.props.highlights }
+    const shadows = { ...theme.shadows, ...this.props.shadows }
 
     const dropdownValue = isVisible ? { name: this.state.name } : theme
 
@@ -138,35 +139,45 @@ class Themes extends React.PureComponent {
             :global(.cm-string),
             :global(.cm-string-2) {
               color: ${highlights.string} !important;
+              text-shadow: ${shadows.string ? shadows.string : 'none'} !important;
             }
             :global(.cm-comment) {
               color: ${highlights.comment} !important;
+              text-shadow: ${shadows.comment ? shadows.comment : 'none'} !important;
             }
             :global(.cm-variable),
             :global(.cm-variable-2),
             :global(.cm-variable-3) {
               color: ${highlights.variable} !important;
+              text-shadow: ${shadows.variable ? shadows.variable : 'none'} !important;
             }
             :global(.cm-number) {
               color: ${highlights.number} !important;
+              text-shadow: ${shadows.number ? shadows.number : 'none'} !important;
             }
             :global(.cm-keyword) {
               color: ${highlights.keyword} !important;
+              text-shadow: ${shadows.keyword ? shadows.keyword : 'none'} !important;
             }
             :global(.cm-property) {
               color: ${highlights.property} !important;
+              text-shadow: ${shadows.property ? shadows.property : 'none'} !important;
             }
             :global(.cm-def) {
               color: ${highlights.definition} !important;
+              text-shadow: ${shadows.definition ? shadows.definition : 'none'} !important;
             }
             :global(.cm-meta) {
               color: ${highlights.meta} !important;
+              text-shadow: ${shadows.meta ? shadows.meta : 'none'} !important;
             }
             :global(.cm-operator) {
               color: ${highlights.operator} !important;
+              text-shadow: ${shadows.operator ? shadows.operator : 'none'} !important;
             }
             :global(.cm-attribute) {
               color: ${highlights.attribute} !important;
+              text-shadow: ${shadows.attribute ? shadows.attribute : 'none'} !important;
             }
 
             :global(.cm-s-dracula .CodeMirror-cursor) {

--- a/components/Themes/index.js
+++ b/components/Themes/index.js
@@ -89,7 +89,6 @@ class Themes extends React.PureComponent {
     const { themes, theme, isVisible, toggleVisibility } = this.props
 
     const highlights = { ...theme.highlights, ...this.props.highlights }
-    const shadows = { ...theme.shadows, ...this.props.shadows }
 
     const dropdownValue = isVisible ? { name: this.state.name } : theme
 
@@ -139,45 +138,35 @@ class Themes extends React.PureComponent {
             :global(.cm-string),
             :global(.cm-string-2) {
               color: ${highlights.string} !important;
-              text-shadow: ${shadows.string ? shadows.string : 'none'} !important;
             }
             :global(.cm-comment) {
               color: ${highlights.comment} !important;
-              text-shadow: ${shadows.comment ? shadows.comment : 'none'} !important;
             }
             :global(.cm-variable),
             :global(.cm-variable-2),
             :global(.cm-variable-3) {
               color: ${highlights.variable} !important;
-              text-shadow: ${shadows.variable ? shadows.variable : 'none'} !important;
             }
             :global(.cm-number) {
               color: ${highlights.number} !important;
-              text-shadow: ${shadows.number ? shadows.number : 'none'} !important;
             }
             :global(.cm-keyword) {
               color: ${highlights.keyword} !important;
-              text-shadow: ${shadows.keyword ? shadows.keyword : 'none'} !important;
             }
             :global(.cm-property) {
               color: ${highlights.property} !important;
-              text-shadow: ${shadows.property ? shadows.property : 'none'} !important;
             }
             :global(.cm-def) {
               color: ${highlights.definition} !important;
-              text-shadow: ${shadows.definition ? shadows.definition : 'none'} !important;
             }
             :global(.cm-meta) {
               color: ${highlights.meta} !important;
-              text-shadow: ${shadows.meta ? shadows.meta : 'none'} !important;
             }
             :global(.cm-operator) {
               color: ${highlights.operator} !important;
-              text-shadow: ${shadows.operator ? shadows.operator : 'none'} !important;
             }
             :global(.cm-attribute) {
               color: ${highlights.attribute} !important;
-              text-shadow: ${shadows.attribute ? shadows.attribute : 'none'} !important;
             }
 
             :global(.cm-s-dracula .CodeMirror-cursor) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -453,7 +453,7 @@ export const THEMES = [
     }
   },
   {
-    id: 'SynthWave-84',
+    id: 'synthwave-84',
     name: "SynthWave '84",
     highlights: {
       background: '#2b213a',
@@ -469,15 +469,6 @@ export const THEMES = [
       comment: '#6d77b3',
       meta: '#ff8b39',
       tag: '#f92aad'
-    },
-    shadows: {
-      variable: '0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3',
-      attribute: '0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75',
-      definition: '0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975',
-      keyword: '0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575',
-      operator: '0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575',
-      property: '0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975',
-      tag: '0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3'
     }
   },
   {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -453,6 +453,34 @@ export const THEMES = [
     }
   },
   {
+    id: 'SynthWave-84',
+    name: "SynthWave '84",
+    highlights: {
+      background: '#2b213a',
+      text: '#b6b1b1',
+      variable: '#f92aad',
+      attribute: '#fff5f6',
+      definition: '#fdfdfd',
+      keyword: '#f4eee4',
+      operator: '#f4eee4',
+      property: '#fdfdfd',
+      number: '#f97e72',
+      string: '#ff8b39',
+      comment: '#6d77b3',
+      meta: '#ff8b39',
+      tag: '#f92aad'
+    },
+    shadows: {
+      variable: '0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3',
+      attribute: '0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75',
+      definition: '0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975',
+      keyword: '0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575',
+      operator: '0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575',
+      property: '0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975',
+      tag: '0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3'
+    }
+  },
+  {
     id: 'tomorrow-night-bright',
     name: 'Tomorrow Night',
     highlights: {

--- a/static/themes/synthwave-84.css
+++ b/static/themes/synthwave-84.css
@@ -1,0 +1,80 @@
+/*
+    Name:       synthwave-84 1.0.0
+    Author:     Robb Owen (https://github.com/robb0wen)
+    Original SynthWave 84' theme (https://github.com/robb0wen/synthwave-vscode)
+*/
+/* basic */
+.CodeMirror.cm-s-synthwave-84 {
+  font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+  font-weight: 350;
+  font-size: 18px;
+  color: #b6b1b1;
+  background-color: #2b213a;
+}
+.cm-s-synthwave-84 .CodeMirror-selected {
+  background-color: #1f172e !important;
+}
+.cm-s-synthwave-84 .CodeMirror-gutter,
+.cm-s-synthwave-84 .CodeMirror-gutters {
+  border: none;
+  background-color: #011627;
+}
+.cm-s-synthwave-84 .CodeMirror-linenumber,
+.cm-s-synthwave-84 .CodeMirror-linenumbers {
+  color: #6d77b3 !important;
+  background-color: transparent;
+}
+.cm-s-synthwave-84 .CodeMirror-lines {
+  color: #b6b1b1 !important;
+  background-color: transparent;
+}
+.cm-s-synthwave-84 .CodeMirror-cursor {
+  border-left: 2px solid #fa7b73 !important;
+}
+/* addon: edit/machingbrackets.js & addon: edit/matchtags.js */
+.cm-s-synthwave-84 .CodeMirror-matchingbracket,
+.cm-s-synthwave-84 .CodeMirror-matchingtag {
+  border-bottom: 2px solid #c792ea;
+  color: #b6b1b1 !important;
+  background-color: transparent;
+}
+.cm-s-synthwave-84 .CodeMirror-nonmatchingbracket {
+  border-bottom: 2px solid #fa7b73;
+  color: #b6b1b1 !important;
+  background-color: transparent;
+}
+/* addon: fold/foldgutter.js */
+.cm-s-synthwave-84 .CodeMirror-foldmarker,
+.cm-s-synthwave-84 .CodeMirror-foldgutter,
+.cm-s-synthwave-84 .CodeMirror-foldgutter-open,
+.cm-s-synthwave-84 .CodeMirror-foldgutter-folded {
+  border: none;
+  text-shadow: none;
+  color: #5c6370 !important;
+  background-color: transparent;
+}
+
+/* addon: selection/active-line.js */
+.cm-s-synthwave-84 .CodeMirror-activeline-background {background-color: #2b213a;}
+/* basic syntax */
+.cm-s-synthwave-84 .cm-quote {color: #6d77b3;font-style: italic;}
+.cm-s-synthwave-84 .cm-negative {color: #fff5f6;text-shadow:0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75;}
+.cm-s-synthwave-84 .cm-positive {color: #fff5f6;text-shadow:0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75;}
+.cm-s-synthwave-84 .cm-strong {color: #f97e72;font-weight: bold;}
+.cm-s-synthwave-84 .cm-em {color: #f4eee4;font-style: italic;text-shadow:0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;}
+.cm-s-synthwave-84 .cm-attribute {color: #fff5f6;text-shadow:0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75;}
+.cm-s-synthwave-84 .cm-link {color: #f97e72;border-bottom: solid 1px #f97e72;}
+.cm-s-synthwave-84 .cm-keyword {color: #f4eee4;font-style: italic;text-shadow:0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;}
+.cm-s-synthwave-84 .cm-def {color: #fdfdfd; text-shadow:0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975;}
+.cm-s-synthwave-84 .cm-atom {color: #f97e72;}
+.cm-s-synthwave-84 .cm-number {color: #f97e72;}
+.cm-s-synthwave-84 .cm-property {color: #fdfdfd;text-shadow:0 0 2px #001716, 0 0 3px #03edf975, 0 0 5px #03edf975, 0 0 8px #03edf975;}
+.cm-s-synthwave-84 .cm-qualifier {color: #f97e72;}
+.cm-s-synthwave-84 .cm-variable {color: #f92aad;text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;}
+.cm-s-synthwave-84 .cm-variable-2 {color: #f92aad;text-shadow: 0 0 2px #100c0f, 0 0 5px #dc078e33, 0 0 10px #fff3;}
+.cm-s-synthwave-84 .cm-string {color: #ff8b39;}
+.cm-s-synthwave-84 .cm-string-2 {color: #ff8b39;}
+.cm-s-synthwave-84 .cm-operator {color: #f4eee4;text-shadow:0 0 2px #393a33, 0 0 8px #f39f0575, 0 0 2px #f39f0575;}
+.cm-s-synthwave-84 .cm-meta {color: #ff8b39;}
+.cm-s-synthwave-84 .cm-comment {color: #6d77b3;font-style: italic;}
+.cm-s-synthwave-84 .cm-error {color: #fff5f6;text-shadow:0 0 2px #000, 0 0 10px #fc1f2c75, 0 0 5px #fc1f2c75, 0 0 25px #fc1f2c75;}


### PR DESCRIPTION
- Extended `THEMES` to include optional `shadows` setting.
- Added SynthWave '84 theme. See https://github.com/robb0wen/synthwave-vscode
- Added optional text shadows to previews.

![carbon(1)](https://user-images.githubusercontent.com/393002/61055721-75516000-a435-11e9-8024-daf3ffb90923.png)

## Description

Thought it would be cool to add text-shadows to the previews. The theme SynthWave '84 looks best with shadows.


Below is the original VS Code theme.

<img width="854" alt="Screen Shot 2019-07-11 at 11 42 57 pm" src="https://user-images.githubusercontent.com/393002/61055820-a2057780-a435-11e9-957f-63dd52c54775.png">



