### PR TITLE
Non foreignObject SVG export added, fixed bug in png export, added a file for creating a devcontainer and made the project compile

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,7 +11,7 @@
 		3000
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "rm -rf .git/hooks/ && yarn install --frozen-lockfile"
+	"postCreateCommand": "rm -rf workspaces/carbon/.git/hooks/ && yarn install --frozen-lockfile"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,7 +11,7 @@
 		3000
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": " rm -rf .git/hooks/ && yarn install --frozen-lockfile"
+	"postCreateCommand": "rm -rf .git/hooks/ && yarn install --frozen-lockfile"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "yarn install --frozen-lockfile"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,19 +4,16 @@
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [3000],
-
+	"forwardPorts": [
+		3000
+	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install --frozen-lockfile"
-
+	"postCreateCommand": " rm -rf .git/hooks/ && yarn install --frozen-lockfile"
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,7 +11,7 @@
 		3000
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install --frozen-lockfile && rm -rf workspaces/carbon/.git/hooks/"
+	"postCreateCommand": "yarn install --frozen-lockfile && rm -rf /workspaces/carbon/.git/hooks/"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,7 +11,7 @@
 		3000
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "rm -rf workspaces/carbon/.git/hooks/ && yarn install --frozen-lockfile"
+	"postCreateCommand": "yarn install --frozen-lockfile && rm -rf workspaces/carbon/.git/hooks/"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ private-key.json
 .now
 .vercel
 *.log
+public/sw.js
+public/workbox-*.js

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import React from 'react'
 import ReactDOM from 'react-dom'
 import dynamic from 'next/dynamic'
 import hljs from 'highlight.js/lib/core'

--- a/components/Carbon.js
+++ b/components/Carbon.js
@@ -1,11 +1,10 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import ReactDOM from 'react-dom'
 import dynamic from 'next/dynamic'
 import hljs from 'highlight.js/lib/core'
 import javascript from 'highlight.js/lib/languages/javascript'
 import debounce from 'lodash.debounce'
 import ms from 'ms'
-import { Controlled as CodeMirror } from 'react-codemirror2'
 
 hljs.registerLanguage('javascript', javascript)
 
@@ -22,6 +21,7 @@ import {
   DEFAULT_SETTINGS,
   THEMES_HASH,
 } from '../lib/constants'
+import CodeMirrorWrapper from './CodeMirrorWrapper'
 
 const SelectionEditor = dynamic(() => import('./SelectionEditor'), {
   loading: () => null,
@@ -29,6 +29,9 @@ const SelectionEditor = dynamic(() => import('./SelectionEditor'), {
 const Watermark = dynamic(() => import('./svg/Watermark'), {
   loading: () => null,
 })
+
+
+
 
 function searchLanguage(l) {
   return LANGUAGE_NAME_HASH[l] || LANGUAGE_MODE_HASH[l] || LANGUAGE_MIME_HASH[l]
@@ -209,7 +212,7 @@ class Carbon extends React.PureComponent {
                   light={light}
                 />
               ) : null}
-              <CodeMirror
+              <CodeMirrorWrapper
                 ref={this.props.editorRef}
                 className={`CodeMirror__container window-theme__${config.windowTheme}`}
                 value={this.props.children}

--- a/components/CodeMirrorWrapper.js
+++ b/components/CodeMirrorWrapper.js
@@ -1,18 +1,9 @@
-import { forwardRef , lazy, Suspense} from 'react'
-const LazyCodeMirror = lazy(() =>
-    import('react-codemirror2').then((module) => ({
-      default: module.Controlled,
-    }))
-  );
-
-const CodeMirrorWrapper = forwardRef(function CodeMirrorWrapper(props, ref) {
-    if (typeof document === 'undefined') {
-        return <></>
-    }
-
-    return (<Suspense fallback={<div>Loading...</div>}>
-        <LazyCodeMirror {...props} ref={ref} />
-    </Suspense>)
-});
-
+let CodeMirrorWrapper
+if (typeof document === 'undefined') {
+  // server context, loading codemirror will cause error, so return a dummy component
+  CodeMirrorWrapper = () => <></>
+} else {
+  // client context, load the component with require, so it is synchronous
+  CodeMirrorWrapper = require('react-codemirror2').Controlled
+}
 export default CodeMirrorWrapper

--- a/components/CodeMirrorWrapper.js
+++ b/components/CodeMirrorWrapper.js
@@ -1,0 +1,18 @@
+import { forwardRef , lazy, Suspense} from 'react'
+const LazyCodeMirror = lazy(() =>
+    import('react-codemirror2').then((module) => ({
+      default: module.Controlled,
+    }))
+  );
+
+const CodeMirrorWrapper = forwardRef(function CodeMirrorWrapper(props, ref) {
+    if (typeof document === 'undefined') {
+        return <></>
+    }
+
+    return (<Suspense fallback={<div>Loading...</div>}>
+        <LazyCodeMirror {...props} ref={ref} />
+    </Suspense>)
+});
+
+export default CodeMirrorWrapper

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -34,7 +34,6 @@ import {
 } from '../lib/constants'
 import { getRouteState } from '../lib/routing'
 import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
-import domtoimage from '../lib/dom-to-image'
 import { nodeToSvg } from '../lib/svg'
 import { nodeToPng } from '../lib/png'
 
@@ -154,8 +153,7 @@ class Editor extends React.Component {
     }
     // alert('format is blob')
     // Twitter and Imgur needs regular dataURLs
-    //TODO: fix this!
-    return domtoimage.toPng(node, config)
+    return nodeToPng(node, config) // untested because the twitter thingy doesn't work locally bit it should work
   }
 
   tweet = () => {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -149,7 +149,7 @@ class Editor extends React.Component {
             .replace(
               // current font-family used
               new RegExp(
-                '@font-face\\s+{\\s+font-family: (?!"*' + this.state.fontFamily + ').*?}',
+                `@font-face\\s*{\\s*font-family:\\s*["']?(?!${this.state.fontFamily})[^'"]*?["']?.*?src:\\s*url\\(['"][^'"]*?base64[^'"]*?['"]\\);[^}]*}`,
                 'g'
               ),
               ''

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -126,6 +126,9 @@ class Editor extends React.Component {
           if (className.includes('CodeMirror-cursors')) {
             return false
           }
+          if (className.includes('CodeMirror-measure')) {
+            return false;
+          }
         }
         return true
       },
@@ -134,8 +137,6 @@ class Editor extends React.Component {
     }
 
     if (format === 'svg') {
-      //console.log(config)
-      //console.log(node)
       return nodeToSvg(node, config)
         .then(dataURL =>
           dataURL
@@ -472,8 +473,8 @@ class Editor extends React.Component {
 }
 
 Editor.defaultProps = {
-  onUpdate: () => {},
-  onReset: () => {},
+  onUpdate: () => { },
+  onReset: () => { },
 }
 
 export default Editor

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -134,8 +134,8 @@ class Editor extends React.Component {
     }
 
     if (format === 'svg') {
-      console.log(config)
-      console.log(node)
+      //console.log(config)
+      //console.log(node)
       return nodeToSvg(node, config)
         .then(dataURL =>
           dataURL

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -35,6 +35,7 @@ import {
 import { getRouteState } from '../lib/routing'
 import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
 import domtoimage from '../lib/dom-to-image'
+import { nodeToSvg } from '../lib/svg'
 
 const languageIcon = <LanguageIcon />
 
@@ -133,8 +134,9 @@ class Editor extends React.Component {
     }
 
     if (format === 'svg') {
-      return domtoimage
-        .toSvg(node, config)
+      console.log(config)
+      console.log(node)
+      return nodeToSvg(node, config)
         .then(dataURL =>
           dataURL
             .replace(/&nbsp;/g, '&#160;')

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -36,6 +36,7 @@ import { getRouteState } from '../lib/routing'
 import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
 import domtoimage from '../lib/dom-to-image'
 import { nodeToSvg } from '../lib/svg'
+import { nodeToPng } from '../lib/png'
 
 const languageIcon = <LanguageIcon />
 
@@ -138,34 +139,19 @@ class Editor extends React.Component {
 
     if (format === 'svg') {
       return nodeToSvg(node, config)
-        .then(dataURL =>
-          dataURL
-            .replace(/&nbsp;/g, '&#160;')
-            // https://github.com/tsayen/dom-to-image/blob/fae625bce0970b3a039671ea7f338d05ecb3d0e8/src/dom-to-image.js#L551
-            .replace(/%23/g, '#')
-            .replace(/%0A/g, '\n')
-            // https://stackoverflow.com/questions/7604436/xmlparseentityref-no-name-warnings-while-loading-xml-into-a-php-file
-            .replace(/&(?!#?[a-z0-9]+;)/g, '&amp;')
-            // remove other fonts which are not used
-            .replace(
-              // current font-family used
-              new RegExp(
-                `@font-face\\s*{\\s*font-family:\\s*["']?(?!${this.state.fontFamily})[^'"]*?["']?.*?src:\\s*url\\(['"][^'"]*?base64[^'"]*?['"]\\);[^}]*}`,
-                'g'
-              ),
-              ''
-            )
-        )
         .then(uri => uri.slice(uri.indexOf(',') + 1))
         .then(data => new Blob([data], { type: 'image/svg+xml' }))
         .catch(console.error)
     }
 
     if (format === 'blob') {
-      return domtoimage.toBlob(node, config)
+      return nodeToPng(node, config)
+        .then(url => fetch(url))
+        .then(res => res.blob())
     }
-
+    // alert('format is blob')
     // Twitter and Imgur needs regular dataURLs
+    //TODO: fix this!
     return domtoimage.toPng(node, config)
   }
 

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -130,6 +130,9 @@ class Editor extends React.Component {
           if (className.includes('CodeMirror-measure')) {
             return false;
           }
+          if (className.includes('handler') && n.role === "separator") {
+            return false;
+          }
         }
         return true
       },

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -157,6 +157,7 @@ class Editor extends React.Component {
         )
         .then(uri => uri.slice(uri.indexOf(',') + 1))
         .then(data => new Blob([data], { type: 'image/svg+xml' }))
+        .catch(console.error)
     }
 
     if (format === 'blob') {

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -1,0 +1,59 @@
+// will download and fetch fonts that are loaded, usable for drawing!
+const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
+
+
+
+export class FontRepo {
+    constructor() {
+        this.fonts = {}
+        console.log("start")
+        this.refresh();
+    }
+
+    async refresh() {
+        const stylesheets = Array.from(document.styleSheets)
+
+        const fontData = []
+        // fetch all the fonts
+        for (const sheet of stylesheets) {
+            try {
+                const rules = sheet.cssRules
+                for (const rule of rules) {
+                    if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url')) {
+                        const font = rule.style.getPropertyValue('font-family').toLowerCase()
+                        const src = rule.style.getPropertyValue('src')
+                        const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
+                        // TODO: dom-to-image has a edge case where the stylesheet has a different url or somehting? check there if this blows up
+                        fontData.push({ font, url })
+                    }
+                }
+            } catch (e) {
+                console.error(e)
+                // not all the css rules can be read and this is fine!
+                // (it's not that important, as long as we get the fonts we don't care)
+            }
+        }
+
+
+        const Uint8FontData = await Promise.all(fontData.map(async ({ font, url }) => {
+            // if it is a data url, just convert to a Uint8Array
+            if (url.startsWith('data:')) {
+                const base64 = url.split(',')[1]
+                const binary = atob(base64)
+                const bytes = new Uint8Array(binary.length)
+                for (let i = 0; i < binary.length; i++) {
+                    bytes[i] = binary.charCodeAt(i)
+                }
+                return { font, data: bytes }
+            }
+
+            // if it is a url, fetch it
+            const response = await fetch(url)
+            const blob = await response.blob()
+            const buffer = await blob.arrayBuffer()
+            return { font, data: new Uint8Array(buffer) }
+        }))
+        console.log(Uint8FontData)
+    }
+}
+

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -1,16 +1,25 @@
+import { parse } from 'opentype.js';
+import { decompress } from 'woff2-encoder';
+
 // will download and fetch fonts that are loaded, usable for drawing!
 const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
 
-
-
 export class FontRepo {
-    constructor() {
+
+
+    constructor() {        
         this.fonts = {}
-        console.log("start")
-        this.refresh();
     }
 
+    
+
     async refresh() {
+        // this can only run on the client!
+        if (typeof document === 'undefined') {
+            return
+        }
+
+
         const stylesheets = Array.from(document.styleSheets)
 
         const fontData = []
@@ -20,22 +29,32 @@ export class FontRepo {
                 const rules = sheet.cssRules
                 for (const rule of rules) {
                     if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url')) {
-                        const font = rule.style.getPropertyValue('font-family').toLowerCase()
+                        const font = rule.style.getPropertyValue('font-family').toLowerCase().replace(/['"]/g, '')
+
+                        // check the global font repo if we already have this font
+                        if (this.fonts[font] !== undefined) {
+                            continue
+                        }
+
                         const src = rule.style.getPropertyValue('src')
+                        const regexResult = src.match(URL_REGEX)
+                        if (regexResult == undefined) {
+                            continue;
+                        }
                         const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
                         // TODO: dom-to-image has a edge case where the stylesheet has a different url or somehting? check there if this blows up
                         fontData.push({ font, url })
                     }
                 }
             } catch (e) {
-                console.error(e)
+                //console.error(e)
                 // not all the css rules can be read and this is fine!
                 // (it's not that important, as long as we get the fonts we don't care)
             }
         }
 
 
-        const Uint8FontData = await Promise.all(fontData.map(async ({ font, url }) => {
+        const uInt8FontData = await Promise.all(fontData.map(async ({ font, url }) => {
             // if it is a data url, just convert to a Uint8Array
             if (url.startsWith('data:')) {
                 const base64 = url.split(',')[1]
@@ -53,7 +72,61 @@ export class FontRepo {
             const buffer = await blob.arrayBuffer()
             return { font, data: new Uint8Array(buffer) }
         }))
-        console.log(Uint8FontData)
+        const toAddFonts = await Promise.all(uInt8FontData.map(async ({ font, data }) => {
+            const format = FontRepo.detectFontFormat(data);
+            let openTypeFont = null;
+            try {
+                if (format === 'WOFF2') {
+                    const decompressed = await decompress(data);
+                    openTypeFont = parse(decompressed.buffer);
+                } else if (format !== null) {
+                    openTypeFont = parse(data.buffer)
+                }
+            } catch (e) {
+                //console.error('Failed to parse font', font, e)
+            }
+
+            return { font, openTypeFont }
+        }))
+
+        toAddFonts.forEach(({ font, openTypeFont }) => {
+            if(openTypeFont === null) {
+                return;
+            }
+            this.fonts[font] = openTypeFont
+        })
+        console.log(this.fonts);
     }
+
+    static detectFontFormat(uint8Array) {
+
+        const first4BytesHex = Array.from(uint8Array.slice(0, 4)) // Extract first 4 bytes
+        .map(byte => byte.toString(16).padStart(2, '0')) // Convert to hex, pad to 2 digits
+        .join(''); // Combine into a single string
+
+        switch (first4BytesHex) {
+          case '774f4632': // WOFF2
+            return 'WOFF2';
+          case '774f4646': // WOFF
+            return 'WOFF';
+          case '00010000': // TTF
+          case '4f54544f': // OTF
+            return 'TTF/OTF';
+          default:
+            throw new Error(`Unknown font format: ${first4BytesHex}`);
+        }
+      }
+
+    getFont(fontFamily) {
+        // split the font family by comma and go through each font, if we have it, return it else zero
+        const fonts = fontFamily.split(',').map(font => font.trim().toLowerCase()).map(font => font.replace(/['"]/g, '').toLowerCase())
+        for (const font of fonts) {
+            if (this.fonts[font] !== undefined) {
+                return this.fonts[font]
+            }
+        }
+        return null
+    }
+
 }
 

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -95,7 +95,7 @@ export class FontRepo {
             }
             this.fonts[font] = openTypeFont
         })
-        console.log(this.fonts);
+        //console.log(this.fonts);
     }
 
     static detectFontFormat(uint8Array) {

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -1,3 +1,4 @@
+// font parsing based on https://github.com/tsayen/dom-to-image
 import { parse } from 'opentype.js';
 // eslint is bullshitting here. woff2-encoder/decompress is valid (see https://github.com/itskyedo/woff2-encoder)
 // eslint-disable-next-line import/no-unresolved

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -1,5 +1,7 @@
 import { parse } from 'opentype.js';
-import { decompress } from 'woff2-encoder';
+// eslint is bullshitting here. woff2-encoder/decompress is valid (see https://github.com/itskyedo/woff2-encoder)
+// eslint-disable-next-line import/no-unresolved
+import decompress from 'woff2-encoder/decompress';
 
 // will download and fetch fonts that are loaded, usable for drawing!
 const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
@@ -7,11 +9,11 @@ const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
 export class FontRepo {
 
 
-    constructor() {        
+    constructor() {
         this.fonts = {}
     }
 
-    
+
 
     async refresh() {
         // this can only run on the client!
@@ -90,7 +92,7 @@ export class FontRepo {
         }))
 
         toAddFonts.forEach(({ font, openTypeFont }) => {
-            if(openTypeFont === null) {
+            if (openTypeFont === null) {
                 return;
             }
             this.fonts[font] = openTypeFont
@@ -101,21 +103,21 @@ export class FontRepo {
     static detectFontFormat(uint8Array) {
 
         const first4BytesHex = Array.from(uint8Array.slice(0, 4)) // Extract first 4 bytes
-        .map(byte => byte.toString(16).padStart(2, '0')) // Convert to hex, pad to 2 digits
-        .join(''); // Combine into a single string
+            .map(byte => byte.toString(16).padStart(2, '0')) // Convert to hex, pad to 2 digits
+            .join(''); // Combine into a single string
 
         switch (first4BytesHex) {
-          case '774f4632': // WOFF2
-            return 'WOFF2';
-          case '774f4646': // WOFF
-            return 'WOFF';
-          case '00010000': // TTF
-          case '4f54544f': // OTF
-            return 'TTF/OTF';
-          default:
-            throw new Error(`Unknown font format: ${first4BytesHex}`);
+            case '774f4632': // WOFF2
+                return 'WOFF2';
+            case '774f4646': // WOFF
+                return 'WOFF';
+            case '00010000': // TTF
+            case '4f54544f': // OTF
+                return 'TTF/OTF';
+            default:
+                throw new Error(`Unknown font format: ${first4BytesHex}`);
         }
-      }
+    }
 
     getFont(fontFamily) {
         // split the font family by comma and go through each font, if we have it, return it else zero

--- a/lib/png.js
+++ b/lib/png.js
@@ -1,0 +1,36 @@
+import { nodeToSvg } from "./svg"
+import { blobToDataURL } from "./util";
+export async function nodeToPng(node, config) {
+    const svgBlob = await nodeToSvg(node, config)
+        .then(uri => uri.slice(uri.indexOf(',') + 1))
+        .then(data => new Blob([data], { type: 'image/svg+xml' }))
+    const svgDataUri = await blobToDataURL(svgBlob);
+
+    // https://zooper.pages.dev/articles/how-to-convert-a-svg-to-png-using-canvas
+    const canvas = document.createElement('canvas')
+    const transformStyle = config.style.transform;
+    const scale = parseFloat(transformStyle.match(/scale\(([^)]+)\)/)[1]) // multiplyer!
+
+    const width = node.getBoundingClientRect().width * scale
+    const height = node.getBoundingClientRect().height * scale
+
+    canvas.width = width
+    canvas.height = height
+    await drawImgToCanvas(svgDataUri, canvas, scale)
+    const pngUrl = canvas.toDataURL('image/png')
+    return pngUrl
+}
+
+function drawImgToCanvas(imgUrl, canvas, scale = 1) {
+    return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.onload = () => {
+            const ctx = canvas.getContext('2d')
+            ctx.scale(scale, scale)
+            ctx.drawImage(img, 0, 0)
+            resolve()
+        }
+        img.onerror = reject
+        img.src = imgUrl
+    })
+}

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -160,7 +160,7 @@ export async function nodeToSvg(node, config) {
 
         for (let i = 0; i < currentNode.childNodes.length; i++) {
             const childNode = currentNode.childNodes[i]
-            if (!filter(childNode) || (childNode.classList?.contains('CodeMirror-measure'))) {
+            if (!filter(childNode)) {
                 continue
             }
             stack.push(childNode)

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -62,6 +62,29 @@ export async function nodeToSvg(node, config) {
             rect.setAttribute('width', rectBounds.width)
             rect.setAttribute('height', rectBounds.height)
             rect.setAttribute('fill', rectStyle.backgroundColor)
+            // convert this node style to style on the rect
+            const nodeStyle = getComputedStyle(currentNode)
+            const borderRadious = nodeStyle.getPropertyValue('border-radius')
+            if (borderRadious != 'none') {
+                rect.setAttribute('rx', borderRadious)
+                rect.setAttribute('ry', borderRadious)
+            }
+            const boxShadow = nodeStyle.getPropertyValue('box-shadow')
+
+            if (boxShadow != 'none') {
+                // swap color and positions on box shadow to get it compatible for drop-shadow
+                // color is in rgba format rba(r, g, b, a)
+                const globalParts = boxShadow.split(') ')
+                const color = globalParts[0] + ')'
+                const posParts = globalParts[1].split(" ")
+                const x = posParts[0]
+                const y = posParts[1]
+                const blur = posParts[2]
+                const spread = posParts[3]
+
+                const dropShadow = `${x} ${y} ${blur} ${spread} ${color}`
+                rect.setAttribute('style', `filter: drop-shadow(${dropShadow});`)
+            }
             svg.appendChild(rect)
             //console.log(rect)
         }

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,0 +1,90 @@
+export async function nodeToSvg(node, config) {
+    const {style, filter, width, height} = config
+
+    const nodeBounds = node.getBoundingClientRect()
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+    if (width) {
+        svg.setAttribute('width', width)
+    }
+    if (height) {
+        svg.setAttribute('height', height)
+    }
+
+    const styleTag = document.createElement('style')
+    styleTag.textContent = `
+        transform: ${style.transform};
+        transform-origin: ${style.transformOrigin};
+        background: ${style.background};
+        align-items: ${style.alignItems};
+        justify-content: ${style.justifyContent};
+    `
+
+    svg.appendChild(styleTag)
+
+    const stack = [node]
+
+    while (stack.length > 0) {
+        const currentNode = stack.pop()
+        // check if is a text node
+        if (currentNode.nodeType === Node.TEXT_NODE) {
+            const textNode = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+            // find parent node
+            const parent = currentNode.parentNode
+            const parentStyle = window.getComputedStyle(parent)
+            // copy parent styles
+            textNode.setAttribute('fill', parentStyle.color)
+            textNode.setAttribute('font-size', parentStyle.fontSize)
+            textNode.setAttribute('font-family', parentStyle.fontFamily)
+
+            const range = document.createRange()
+            range.selectNode(currentNode)
+            const rect = range.getBoundingClientRect()
+            const offsetX = rect.x - nodeBounds.x
+            const offsetY = rect.y - nodeBounds.y
+            textNode.setAttribute('x', offsetX)
+            textNode.setAttribute('y', offsetY)
+            
+            textNode.textContent = currentNode.textContent
+            svg.appendChild(textNode)
+            continue
+        }
+
+        // if has no children and not ignored and is div, we convert it to a rect
+        if (filter(currentNode) && currentNode.tagName === 'DIV') {
+            const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+            const rectStyle = window.getComputedStyle(currentNode)
+
+            const rectBounds = currentNode.getBoundingClientRect()
+            const offsetX = rectBounds.x - nodeBounds.x
+            const offsetY = rectBounds.y - nodeBounds.y
+
+            rect.setAttribute('x', offsetX)
+            rect.setAttribute('y', offsetY)
+            rect.setAttribute('width', rectBounds.width)
+            rect.setAttribute('height', rectBounds.height)
+            rect.setAttribute('fill', rectStyle.backgroundColor)
+            svg.appendChild(rect)
+            console.log(rect)
+        }
+
+
+        for (let i = 0; i < currentNode.childNodes.length; i++) {
+            const childNode = currentNode.childNodes[i]
+            if (!filter(childNode) || (childNode.classList?.contains('CodeMirror-measure'))) {
+                continue
+            }
+            stack.push(childNode)
+        }
+    }
+
+
+    // convert svg to data url
+    const svgString = new XMLSerializer().serializeToString(svg)
+    return `data:image/svg+xml,${svgString}`
+
+
+
+}

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -67,7 +67,8 @@ export async function nodeToSvg(node, config) {
                 textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
                 svg.appendChild(textNode)
             } else {
-                const path = font.getPath(currentNode.textContent, offsetX, offsetY, parentStyle.fontSize.replace('px', ''))
+                const fontSize = parseInt(parentStyle.fontSize.replace('px', ''))
+                const path = font.getPath(currentNode.textContent, offsetX, offsetY + fontSize, fontSize)
                 const svgPath = path.toDOMElement()
                 // set color
                 svgPath.setAttribute('fill', parentStyle.color)

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,17 +1,13 @@
 export async function nodeToSvg(node, config) {
-    const {style, filter, width, height} = config
+    const {style, filter} = config
 
     const nodeBounds = node.getBoundingClientRect()
 
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
     svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
 
-    if (width) {
-        svg.setAttribute('width', width)
-    }
-    if (height) {
-        svg.setAttribute('height', height)
-    }
+    svg.setAttribute('width', nodeBounds.width)
+    svg.setAttribute('height', nodeBounds.height)
 
     const styleTag = document.createElement('style')
     styleTag.textContent = `

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,4 +1,55 @@
 import { v4 as uuidv4 } from 'uuid';
+// getting fonts inspirered by dom-to-image
+const URL_REGEX  = /url\(['"]?([^'"]+?)['"]?\)/g
+async function getFonts(namespace = 'http://www.w3.org/1999/xhtml') {
+    const stylesheets = Array.from(document.styleSheets)
+
+    const fontRules = []
+    for (const sheet of stylesheets) {
+        try {
+            const rules = sheet.cssRules
+            for (const rule of rules) {
+                if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url')) {
+                    const font = rule.style.getPropertyValue('font-family')
+                    const src = rule.style.getPropertyValue('src')
+                    const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
+                    // TODO: dom-to-image has a edge case where the stylesheet has a different url or somehting? check there if this blows up
+                    fontRules.push({font, url})
+                }
+            }
+        } catch (e) {
+            // not all the css rules can be read and this is fine!
+            // (it's not that important, as long as we get the fonts we don't care)
+        }
+    }
+    const fontBase64Data = await Promise.all(
+        fontRules.map(async ({font, url}) => {
+            const type = url.split('.').pop()
+            const response = await fetch(url)
+            const blob = await response.blob()
+            const base64 = await new Promise((resolve) => {
+                const reader = new FileReader()
+                reader.onload = () => resolve(reader.result)
+                reader.readAsDataURL(blob)
+            })
+
+            return {font, base64, type}
+        }))
+    const styleTag = document.createElementNS(namespace, 'style')
+    for (const {font, base64, type} of fontBase64Data) {
+        // add to the style tag
+        styleTag.textContent += `
+            @font-face {
+                font-family: '${font}';
+                src: url('${base64}');
+                format('${type}');
+            }
+        `
+    }
+    return styleTag
+
+    
+}
 
 export async function nodeToSvg(node, config) {
     const {style, filter} = config
@@ -21,6 +72,9 @@ export async function nodeToSvg(node, config) {
     `
 
     svg.appendChild(styleTag)
+    // svg namespace
+    const fontStyleTag = await getFonts('http://www.w3.org/2000/svg').catch(console.error)
+    svg.appendChild(fontStyleTag)
 
     const stack = [node]
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -130,9 +130,6 @@ export async function nodeToSvg(node, config) {
                     dropShadow.setAttribute('flood-color', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
                     dropShadow.setAttribute('flood-opacity', colorParts[3])
                     filter.appendChild(dropShadow)
-                    const feComposite = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite')
-                    feComposite.setAttribute('operator', 'out')
-                    filter.appendChild(feComposite)
                     svg.appendChild(filter)
 
                     // clone the rect and apply the filter

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,89 +1,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import { FontRepo } from './fonts';
 // getting fonts inspirered by dom-to-image
-const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
+const fontRepo = new FontRepo();
 
-
-
-function doFontsFuzzyMatch(fontsToInclude, font) {
-    const strippedFont = font.replace(/['"]/g, '').toLowerCase()
-    return fontsToInclude.some((fontToInclude) => {
-        return fontToInclude.toLowerCase() === strippedFont
-    })
-}
-
-function getFileExtension(url) {
-    // First, remove any query parameters or fragments
-    const urlWithoutParams = url.split('?')[0].split('#')[0];
-
-    // Find the last period in the URL and return everything after it
-    const extension = urlWithoutParams.split('.').pop();
-
-    // Check if the extension is valid (e.g., if the URL has an extension)
-    if (extension !== urlWithoutParams) {
-        return extension; // Return the file extension
-    } else {
-        return null; // No extension found
-    }
-}
-
-async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtml') {
-    const stylesheets = Array.from(document.styleSheets)
-
-    const fontRules = []
-    for (const sheet of stylesheets) {
-        try {
-            const rules = sheet.cssRules
-            for (const rule of rules) {
-                if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url') && doFontsFuzzyMatch(fontsToInclude, rule.style.getPropertyValue('font-family'))) {
-                    const font = rule.style.getPropertyValue('font-family')
-                    const src = rule.style.getPropertyValue('src')
-                    const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
-                    // TODO: dom-to-image has a edge case where the stylesheet has a different url or somehting? check there if this blows up
-                    fontRules.push({ font, url })
-                }
-            }
-        } catch (e) {
-            console.error(e)
-            // not all the css rules can be read and this is fine!
-            // (it's not that important, as long as we get the fonts we don't care)
-        }
-    }
-    const fontBase64Data = await Promise.all(
-        fontRules.map(async ({ font, url }) => {
-            const type = getFileExtension(url)
-            const response = await fetch(url)
-            const blob = await response.blob()
-            const base64 = await new Promise((resolve) => {
-                const reader = new FileReader()
-                reader.onload = () => resolve(reader.result)
-                reader.readAsDataURL(blob)
-            })
-
-            return { font, base64, type }
-        }))
-    const styleTag = document.createElementNS(namespace, 'style')
-    for (const { font, base64, type } of fontBase64Data) {
-        // add to the style tag
-        // https://stackoverflow.com/questions/26867893/converting-and-rendering-web-fonts-to-base64-keep-original-look
-        const templateOfUrl = `data:font/${type};charset=utf-8;base64,${base64}`
-        styleTag.textContent += `
-            @font-face {
-                font-family: '${font}';
-                src: url('${templateOfUrl}');
-                format('${type}');
-            }
-        `
-    }
-    return styleTag
-
-
-}
 
 export async function nodeToSvg(node, config) {
-    alert("test")
-    const fontRepo = new FontRepo();
     const { style, filter } = config
+    await fontRepo.refresh();
 
     const nodeBounds = node.getBoundingClientRect()
 
@@ -112,26 +35,46 @@ export async function nodeToSvg(node, config) {
         const currentNode = stack.pop()
         // check if is a text node
         if (currentNode.nodeType === Node.TEXT_NODE) {
-            const textNode = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+            // if the node has no content, we skip it
+            if (currentNode.textContent.trim() === '' || currentNode.textContent.charCodeAt(0).toString(16) === '200b') {
+                continue
+            }
+            //const charCodeStr = currentNode.textContent.charCodeAt(0).toString(16)
+            //console.log(currentNode.textContent, charCodeStr)
             // find parent node
             const parent = currentNode.parentNode
             const parentStyle = window.getComputedStyle(parent)
-            // copy parent styles
-            textNode.setAttribute('fill', parentStyle.color)
-            textNode.setAttribute('font-size', parentStyle.fontSize)
-            textNode.setAttribute('font-family', parentStyle.fontFamily)
-            parentStyle.fontFamily.split(',').forEach(font => neededFonts.add(font.trim()))
-
             const range = document.createRange()
             range.selectNode(currentNode)
             const rect = range.getBoundingClientRect()
             const offsetX = rect.x - nodeBounds.x
             const offsetY = rect.y - nodeBounds.y
+            // copy parent styles
+            const font = fontRepo.getFont(parentStyle.fontFamily)
+            if (font === null) {
+                const textNode = document.createElementNS('http://www.w3.org/2000/svg', 'text')
+            textNode.setAttribute('fill', parentStyle.color)
+            textNode.setAttribute('font-size', parentStyle.fontSize)
+            textNode.setAttribute('font-family', parentStyle.fontFamily)
+            parentStyle.fontFamily.split(',').forEach(font => neededFonts.add(font.trim()))
+
+           
             textNode.setAttribute('x', offsetX)
             textNode.setAttribute('y', offsetY)
 
+
+
             textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
             svg.appendChild(textNode)
+            } else {
+                const path = font.getPath(currentNode.textContent, offsetX, offsetY, parentStyle.fontSize.replace('px', ''))
+                const svgPath = path.toDOMElement()
+                // set color
+                svgPath.setAttribute('fill', parentStyle.color)
+                // start
+                svg.appendChild(svgPath)
+            }
+            
             continue
         }
 
@@ -211,9 +154,6 @@ export async function nodeToSvg(node, config) {
             stack.push(childNode)
         }
     }
-
-    const fontStyleTag = await getFonts([...neededFonts], 'http://www.w3.org/2000/svg').catch(console.error)
-    svg.appendChild(fontStyleTag)
 
 
     // convert svg to data url

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from 'uuid';
+import { FontRepo } from './fonts';
 // getting fonts inspirered by dom-to-image
-const URL_REGEX  = /url\(['"]?([^'"]+?)['"]?\)/g
+const URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g
+
+
 
 function doFontsFuzzyMatch(fontsToInclude, font) {
     const strippedFont = font.replace(/['"]/g, '').toLowerCase()
@@ -12,17 +15,17 @@ function doFontsFuzzyMatch(fontsToInclude, font) {
 function getFileExtension(url) {
     // First, remove any query parameters or fragments
     const urlWithoutParams = url.split('?')[0].split('#')[0];
-    
+
     // Find the last period in the URL and return everything after it
     const extension = urlWithoutParams.split('.').pop();
-    
+
     // Check if the extension is valid (e.g., if the URL has an extension)
     if (extension !== urlWithoutParams) {
-      return extension; // Return the file extension
+        return extension; // Return the file extension
     } else {
-      return null; // No extension found
+        return null; // No extension found
     }
-  }
+}
 
 async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtml') {
     const stylesheets = Array.from(document.styleSheets)
@@ -37,7 +40,7 @@ async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtm
                     const src = rule.style.getPropertyValue('src')
                     const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
                     // TODO: dom-to-image has a edge case where the stylesheet has a different url or somehting? check there if this blows up
-                    fontRules.push({font, url})
+                    fontRules.push({ font, url })
                 }
             }
         } catch (e) {
@@ -47,7 +50,7 @@ async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtm
         }
     }
     const fontBase64Data = await Promise.all(
-        fontRules.map(async ({font, url}) => {
+        fontRules.map(async ({ font, url }) => {
             const type = getFileExtension(url)
             const response = await fetch(url)
             const blob = await response.blob()
@@ -57,10 +60,10 @@ async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtm
                 reader.readAsDataURL(blob)
             })
 
-            return {font, base64, type}
+            return { font, base64, type }
         }))
     const styleTag = document.createElementNS(namespace, 'style')
-    for (const {font, base64, type} of fontBase64Data) {
+    for (const { font, base64, type } of fontBase64Data) {
         // add to the style tag
         // https://stackoverflow.com/questions/26867893/converting-and-rendering-web-fonts-to-base64-keep-original-look
         const templateOfUrl = `data:font/${type};charset=utf-8;base64,${base64}`
@@ -74,11 +77,13 @@ async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtm
     }
     return styleTag
 
-    
+
 }
 
 export async function nodeToSvg(node, config) {
-    const {style, filter} = config
+    alert("test")
+    const fontRepo = new FontRepo();
+    const { style, filter } = config
 
     const nodeBounds = node.getBoundingClientRect()
 
@@ -99,7 +104,7 @@ export async function nodeToSvg(node, config) {
 
     svg.appendChild(styleTag)
     const neededFonts = new Set();
-    
+
 
     const stack = [node]
 
@@ -124,7 +129,7 @@ export async function nodeToSvg(node, config) {
             const offsetY = rect.y - nodeBounds.y
             textNode.setAttribute('x', offsetX)
             textNode.setAttribute('y', offsetY)
-            
+
             textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
             svg.appendChild(textNode)
             continue
@@ -207,7 +212,7 @@ export async function nodeToSvg(node, config) {
         }
     }
 
-    const fontStyleTag = await getFonts([...neededFonts],'http://www.w3.org/2000/svg').catch(console.error)
+    const fontStyleTag = await getFonts([...neededFonts], 'http://www.w3.org/2000/svg').catch(console.error)
     svg.appendChild(fontStyleTag)
 
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -79,70 +79,82 @@ export async function nodeToSvg(node, config) {
         }
 
         // if has no children and not ignored and is div, we convert it to a rect
-        if (filter(currentNode) && currentNode.tagName === 'DIV') {
-            const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
-            const rectStyle = window.getComputedStyle(currentNode)
+        if (filter(currentNode)) {
+            if (currentNode.tagName === 'DIV') {
+                const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+                const rectStyle = window.getComputedStyle(currentNode)
 
-            const rectBounds = currentNode.getBoundingClientRect()
-            const offsetX = rectBounds.x - nodeBounds.x
-            const offsetY = rectBounds.y - nodeBounds.y
+                const rectBounds = currentNode.getBoundingClientRect()
+                const offsetX = rectBounds.x - nodeBounds.x
+                const offsetY = rectBounds.y - nodeBounds.y
 
-            rect.setAttribute('x', offsetX)
-            rect.setAttribute('y', offsetY)
-            rect.setAttribute('width', rectBounds.width)
-            rect.setAttribute('height', rectBounds.height)
-            rect.setAttribute('fill', rectStyle.backgroundColor)
-            // convert this node style to style on the rect
-            const nodeStyle = getComputedStyle(currentNode)
-            const borderRadious = nodeStyle.getPropertyValue('border-radius')
-            if (borderRadious != 'none') {
-                rect.setAttribute('rx', borderRadious)
-                rect.setAttribute('ry', borderRadious)
+                rect.setAttribute('x', offsetX)
+                rect.setAttribute('y', offsetY)
+                rect.setAttribute('width', rectBounds.width)
+                rect.setAttribute('height', rectBounds.height)
+                rect.setAttribute('fill', rectStyle.backgroundColor)
+                // convert this node style to style on the rect
+                const nodeStyle = getComputedStyle(currentNode)
+                const borderRadious = nodeStyle.getPropertyValue('border-radius')
+                if (borderRadious != 'none') {
+                    rect.setAttribute('rx', borderRadious)
+                    rect.setAttribute('ry', borderRadious)
+                }
+                const boxShadow = nodeStyle.getPropertyValue('box-shadow')
+
+                if (boxShadow != 'none') {
+                    // swap color and positions on box shadow to get it compatible for drop-shadow
+                    // color is in rgba format rba(r, g, b, a)
+                    const globalParts = boxShadow.split(') ')
+                    const colorRGBA = globalParts[0] + ')'
+                    const colorParts = colorRGBA.split('(')[1].split(',')
+                    colorParts[3] = colorParts[3].replace(')', '')
+                    const posParts = globalParts[1].split(" ")
+                    const x = posParts[0].replace('px', '')
+                    const y = posParts[1].replace('px', '')
+                    const blur = posParts[2].replace('px', '')
+
+                    // create a filter for the shadow
+                    const filter = document.createElementNS('http://www.w3.org/2000/svg', 'filter')
+                    const uuid = uuidv4()
+                    filter.setAttribute('id', uuid)
+                    filter.setAttribute('x', '-50%')
+                    filter.setAttribute('y', '-50%')
+                    filter.setAttribute('width', '200%')
+                    filter.setAttribute('height', '200%')
+                    const dropShadow = document.createElementNS('http://www.w3.org/2000/svg', 'feDropShadow')
+                    dropShadow.setAttribute('dx', x)
+                    dropShadow.setAttribute('dy', y)
+                    dropShadow.setAttribute('stdDeviation', parseFloat(blur) / 2)
+                    dropShadow.setAttribute('flood-color', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
+                    dropShadow.setAttribute('flood-opacity', colorParts[3])
+                    filter.appendChild(dropShadow)
+                    const feComposite = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite')
+                    feComposite.setAttribute('operator', 'out')
+                    filter.appendChild(feComposite)
+                    svg.appendChild(filter)
+
+                    // clone the rect and apply the filter
+                    const rectClone = rect.cloneNode()
+                    rectClone.setAttribute('filter', `url(#${uuid})`)
+                    rectClone.setAttribute('fill', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
+                    svg.appendChild(rectClone)
+
+                }
+                svg.appendChild(rect)
+                //console.log(rect)
+            } else if (currentNode.tagName === "svg") {
+                const svgElement = currentNode.cloneNode(true)
+                const svgBounds = currentNode.getBoundingClientRect()
+                const offsetX = svgBounds.x - nodeBounds.x
+                const offsetY = svgBounds.y - nodeBounds.y
+                svgElement.setAttribute('x', offsetX)
+                svgElement.setAttribute('y', offsetY)
+                svg.appendChild(svgElement)
             }
-            const boxShadow = nodeStyle.getPropertyValue('box-shadow')
-
-            if (boxShadow != 'none') {
-                // swap color and positions on box shadow to get it compatible for drop-shadow
-                // color is in rgba format rba(r, g, b, a)
-                const globalParts = boxShadow.split(') ')
-                const colorRGBA = globalParts[0] + ')'
-                const colorParts = colorRGBA.split('(')[1].split(',')
-                colorParts[3] = colorParts[3].replace(')', '')
-                const posParts = globalParts[1].split(" ")
-                const x = posParts[0].replace('px', '')
-                const y = posParts[1].replace('px', '')
-                const blur = posParts[2].replace('px', '')
-
-                // create a filter for the shadow
-                const filter = document.createElementNS('http://www.w3.org/2000/svg', 'filter')
-                const uuid = uuidv4()
-                filter.setAttribute('id', uuid)
-                filter.setAttribute('x', '-50%')
-                filter.setAttribute('y', '-50%')
-                filter.setAttribute('width', '200%')
-                filter.setAttribute('height', '200%')
-                const dropShadow = document.createElementNS('http://www.w3.org/2000/svg', 'feDropShadow')
-                dropShadow.setAttribute('dx', x)
-                dropShadow.setAttribute('dy', y)
-                dropShadow.setAttribute('stdDeviation', parseFloat(blur) / 2)
-                dropShadow.setAttribute('flood-color', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
-                dropShadow.setAttribute('flood-opacity', colorParts[3])
-                filter.appendChild(dropShadow)
-                const feComposite = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite')
-                feComposite.setAttribute('operator', 'out')
-                filter.appendChild(feComposite)
-                svg.appendChild(filter)
-
-                // clone the rect and apply the filter
-                const rectClone = rect.cloneNode()
-                rectClone.setAttribute('filter', `url(#${uuid})`)
-                rectClone.setAttribute('fill', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
-                svg.appendChild(rectClone)
-
-            }
-            svg.appendChild(rect)
-            //console.log(rect)
         }
+        //console.log(currentNode)
+
 
 
         for (let i = 0; i < currentNode.childNodes.length; i++) {

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -139,7 +139,21 @@ export async function nodeToSvg(node, config) {
                     svg.appendChild(rectClone)
 
                 }
-                svg.appendChild(rect)
+                // if the rect color is transparent, we remove the rect
+                let isTransparent = false
+                if (rectStyle.backgroundColor === "transparent") {
+                    isTransparent
+                }
+                if (rectStyle.backgroundColor.startsWith('rgba')) {
+                    const colorParts = rectStyle.backgroundColor.split(',')
+                    const alphaPart = colorParts[3].replace(')', '').trim()
+                    if (alphaPart === '0') {
+                        isTransparent = true
+                    }
+                }
+                if (!isTransparent) {
+                    svg.appendChild(rect)
+                }
                 //console.log(rect)
             } else if (currentNode.tagName === "svg") {
                 const svgElement = currentNode.cloneNode(true)

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export async function nodeToSvg(node, config) {
     const {style, filter} = config
 
@@ -43,7 +45,7 @@ export async function nodeToSvg(node, config) {
             textNode.setAttribute('x', offsetX)
             textNode.setAttribute('y', offsetY)
             
-            textNode.textContent = currentNode.textContent
+            textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
             svg.appendChild(textNode)
             continue
         }
@@ -75,15 +77,41 @@ export async function nodeToSvg(node, config) {
                 // swap color and positions on box shadow to get it compatible for drop-shadow
                 // color is in rgba format rba(r, g, b, a)
                 const globalParts = boxShadow.split(') ')
-                const color = globalParts[0] + ')'
+                const colorRGBA = globalParts[0] + ')'
+                const colorParts = colorRGBA.split('(')[1].split(',')
+                colorParts[3] = colorParts[3].replace(')', '')
                 const posParts = globalParts[1].split(" ")
-                const x = posParts[0]
-                const y = posParts[1]
-                const blur = posParts[2]
-                const spread = posParts[3]
+                const x = posParts[0].replace('px', '')
+                const y = posParts[1].replace('px', '')
+                const blur = posParts[2].replace('px', '')
 
-                const dropShadow = `${x} ${y} ${blur} ${spread} ${color}`
-                rect.setAttribute('style', `filter: drop-shadow(${dropShadow});`)
+                // create a filter for the shadow
+                const filter = document.createElementNS('http://www.w3.org/2000/svg', 'filter')
+                const uuid = uuidv4()
+                filter.setAttribute('id', uuid)
+                filter.setAttribute('x', '-50%')
+                filter.setAttribute('y', '-50%')
+                filter.setAttribute('width', '200%')
+                filter.setAttribute('height', '200%')
+                const dropShadow = document.createElementNS('http://www.w3.org/2000/svg', 'feDropShadow')
+                dropShadow.setAttribute('dx', x)
+                dropShadow.setAttribute('dy', y)
+                dropShadow.setAttribute('stdDeviation', parseFloat(blur) / 2)
+                dropShadow.setAttribute('flood-color', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
+                dropShadow.setAttribute('flood-opacity', colorParts[3])
+                filter.appendChild(dropShadow)
+                svg.appendChild(filter)
+                rect.setAttribute('filter', `url(#${uuid})`)
+
+                // if the current rect has a alpha of zero, use a child color if it exists
+                if (rectStyle.backgroundColor == 'rgba(0, 0, 0, 0)') {
+                    const child = currentNode.children[0]
+                    if (child) {
+                        const childStyle = window.getComputedStyle(child)
+                        rect.setAttribute('fill', childStyle.backgroundColor)
+                    }
+                }
+
             }
             svg.appendChild(rect)
             //console.log(rect)

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,7 +1,30 @@
 import { v4 as uuidv4 } from 'uuid';
 // getting fonts inspirered by dom-to-image
 const URL_REGEX  = /url\(['"]?([^'"]+?)['"]?\)/g
-async function getFonts(namespace = 'http://www.w3.org/1999/xhtml') {
+
+function doFontsFuzzyMatch(fontsToInclude, font) {
+    const strippedFont = font.replace(/['"]/g, '').toLowerCase()
+    return fontsToInclude.some((fontToInclude) => {
+        return fontToInclude.toLowerCase() === strippedFont
+    })
+}
+
+function getFileExtension(url) {
+    // First, remove any query parameters or fragments
+    const urlWithoutParams = url.split('?')[0].split('#')[0];
+    
+    // Find the last period in the URL and return everything after it
+    const extension = urlWithoutParams.split('.').pop();
+    
+    // Check if the extension is valid (e.g., if the URL has an extension)
+    if (extension !== urlWithoutParams) {
+      return extension; // Return the file extension
+    } else {
+      return null; // No extension found
+    }
+  }
+
+async function getFonts(fontsToInclude, namespace = 'http://www.w3.org/1999/xhtml') {
     const stylesheets = Array.from(document.styleSheets)
 
     const fontRules = []
@@ -9,7 +32,7 @@ async function getFonts(namespace = 'http://www.w3.org/1999/xhtml') {
         try {
             const rules = sheet.cssRules
             for (const rule of rules) {
-                if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url')) {
+                if (rule.constructor.name == 'CSSFontFaceRule' && rule.style.getPropertyValue('src').includes('url') && doFontsFuzzyMatch(fontsToInclude, rule.style.getPropertyValue('font-family'))) {
                     const font = rule.style.getPropertyValue('font-family')
                     const src = rule.style.getPropertyValue('src')
                     const url = src.match(URL_REGEX)[0].replace(URL_REGEX, '$1')
@@ -18,13 +41,14 @@ async function getFonts(namespace = 'http://www.w3.org/1999/xhtml') {
                 }
             }
         } catch (e) {
+            console.error(e)
             // not all the css rules can be read and this is fine!
             // (it's not that important, as long as we get the fonts we don't care)
         }
     }
     const fontBase64Data = await Promise.all(
         fontRules.map(async ({font, url}) => {
-            const type = url.split('.').pop()
+            const type = getFileExtension(url)
             const response = await fetch(url)
             const blob = await response.blob()
             const base64 = await new Promise((resolve) => {
@@ -38,10 +62,12 @@ async function getFonts(namespace = 'http://www.w3.org/1999/xhtml') {
     const styleTag = document.createElementNS(namespace, 'style')
     for (const {font, base64, type} of fontBase64Data) {
         // add to the style tag
+        // https://stackoverflow.com/questions/26867893/converting-and-rendering-web-fonts-to-base64-keep-original-look
+        const templateOfUrl = `data:font/${type};charset=utf-8;base64,${base64}`
         styleTag.textContent += `
             @font-face {
                 font-family: '${font}';
-                src: url('${base64}');
+                src: url('${templateOfUrl}');
                 format('${type}');
             }
         `
@@ -72,9 +98,8 @@ export async function nodeToSvg(node, config) {
     `
 
     svg.appendChild(styleTag)
-    // svg namespace
-    const fontStyleTag = await getFonts('http://www.w3.org/2000/svg').catch(console.error)
-    svg.appendChild(fontStyleTag)
+    const neededFonts = new Set();
+    
 
     const stack = [node]
 
@@ -90,6 +115,7 @@ export async function nodeToSvg(node, config) {
             textNode.setAttribute('fill', parentStyle.color)
             textNode.setAttribute('font-size', parentStyle.fontSize)
             textNode.setAttribute('font-family', parentStyle.fontFamily)
+            parentStyle.fontFamily.split(',').forEach(font => neededFonts.add(font.trim()))
 
             const range = document.createRange()
             range.selectNode(currentNode)
@@ -180,6 +206,9 @@ export async function nodeToSvg(node, config) {
             stack.push(childNode)
         }
     }
+
+    const fontStyleTag = await getFonts([...neededFonts],'http://www.w3.org/2000/svg').catch(console.error)
+    svg.appendChild(fontStyleTag)
 
 
     // convert svg to data url

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -67,7 +67,7 @@ export async function nodeToSvg(node, config) {
             rect.setAttribute('height', rectBounds.height)
             rect.setAttribute('fill', rectStyle.backgroundColor)
             svg.appendChild(rect)
-            console.log(rect)
+            //console.log(rect)
         }
 
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -53,19 +53,19 @@ export async function nodeToSvg(node, config) {
             const font = fontRepo.getFont(parentStyle.fontFamily)
             if (font === null) {
                 const textNode = document.createElementNS('http://www.w3.org/2000/svg', 'text')
-            textNode.setAttribute('fill', parentStyle.color)
-            textNode.setAttribute('font-size', parentStyle.fontSize)
-            textNode.setAttribute('font-family', parentStyle.fontFamily)
-            parentStyle.fontFamily.split(',').forEach(font => neededFonts.add(font.trim()))
-
-           
-            textNode.setAttribute('x', offsetX)
-            textNode.setAttribute('y', offsetY)
+                textNode.setAttribute('fill', parentStyle.color)
+                textNode.setAttribute('font-size', parentStyle.fontSize)
+                textNode.setAttribute('font-family', parentStyle.fontFamily)
+                parentStyle.fontFamily.split(',').forEach(font => neededFonts.add(font.trim()))
 
 
+                textNode.setAttribute('x', offsetX)
+                textNode.setAttribute('y', offsetY)
 
-            textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
-            svg.appendChild(textNode)
+
+
+                textNode.textContent = currentNode.textContent.replace(' ', '\u00A0')
+                svg.appendChild(textNode)
             } else {
                 const path = font.getPath(currentNode.textContent, offsetX, offsetY, parentStyle.fontSize.replace('px', ''))
                 const svgPath = path.toDOMElement()
@@ -74,7 +74,7 @@ export async function nodeToSvg(node, config) {
                 // start
                 svg.appendChild(svgPath)
             }
-            
+
             continue
         }
 
@@ -128,17 +128,16 @@ export async function nodeToSvg(node, config) {
                 dropShadow.setAttribute('flood-color', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
                 dropShadow.setAttribute('flood-opacity', colorParts[3])
                 filter.appendChild(dropShadow)
+                const feComposite = document.createElementNS('http://www.w3.org/2000/svg', 'feComposite')
+                feComposite.setAttribute('operator', 'out')
+                filter.appendChild(feComposite)
                 svg.appendChild(filter)
-                rect.setAttribute('filter', `url(#${uuid})`)
 
-                // if the current rect has a alpha of zero, use a child color if it exists
-                if (rectStyle.backgroundColor == 'rgba(0, 0, 0, 0)') {
-                    const child = currentNode.children[0]
-                    if (child) {
-                        const childStyle = window.getComputedStyle(child)
-                        rect.setAttribute('fill', childStyle.backgroundColor)
-                    }
-                }
+                // clone the rect and apply the filter
+                const rectClone = rect.cloneNode()
+                rectClone.setAttribute('filter', `url(#${uuid})`)
+                rectClone.setAttribute('fill', `rgb(${colorParts[0]}, ${colorParts[1]}, ${colorParts[2]})`)
+                svg.appendChild(rectClone)
 
             }
             svg.appendChild(rect)

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,3 +94,12 @@ export const formatCode = async code => {
 export const stringifyColor = obj => `rgba(${obj.rgb.r},${obj.rgb.g},${obj.rgb.b},${obj.rgb.a})`
 
 export const generateId = () => Math.random().toString(36).slice(2)
+
+export function blobToDataURL(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ms": "^2.1.3",
     "next": "^12.1.6",
     "next-pwa": "^5.5.2",
+    "opentype.js": "^1.3.4",
     "prettier": "^2.6.2",
     "puppeteer-core": "^9.0.0",
     "react": "^17.0.2",
@@ -63,7 +64,8 @@
     "react-dom": "^17.0.2",
     "react-image-crop": "^6.0.16",
     "tohash": "^1.0.2",
-    "uuid": "^11.0.5"
+    "uuid": "^11.0.5",
+    "wawoff2": "^2.0.1"
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.25.7",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "react-color": "^2.19.3",
     "react-dom": "^17.0.2",
     "react-image-crop": "^6.0.16",
-    "tohash": "^1.0.2"
+    "tohash": "^1.0.2",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.25.7",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-image-crop": "^6.0.16",
     "tohash": "^1.0.2",
     "uuid": "^11.0.5",
-    "wawoff2": "^2.0.1"
+    "woff2-encoder": "^1.1.0"
   },
   "devDependencies": {
     "@applitools/eyes-cypress": "^3.25.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8333,13 +8333,6 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-wawoff2@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/wawoff2/-/wawoff2-2.0.1.tgz#474d8ccae33da3863abad0ee64b70b6db51acac2"
-  integrity sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==
-  dependencies:
-    argparse "^2.0.1"
-
 web-encoding@1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
@@ -8536,6 +8529,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+woff2-encoder@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/woff2-encoder/-/woff2-encoder-1.1.0.tgz#d8e0091877ee1173a57c04d5586a9c6889b31e12"
+  integrity sha512-hV0IFk4oSgMXU8xdxwARwDuZ6NihFCH06kTraSHsuxW0R96C/qG8ebcLKz2+UvOzzZAqraMjpFmKYXUur6mRPg==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8235,6 +8235,11 @@ uuid@8.3.2, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
+  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6378,6 +6378,14 @@ opener@^1.5.2:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
+opentype.js@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/opentype.js/-/opentype.js-1.3.4.tgz#1c0e72e46288473cc4a4c6a2dc60fd7fe6020d77"
+  integrity sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==
+  dependencies:
+    string.prototype.codepointat "^0.2.1"
+    tiny-inflate "^1.0.3"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -7647,6 +7655,11 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string.prototype.codepointat@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
+  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
+
 string.prototype.matchall@^4.0.6, string.prototype.matchall@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz#8e6ecb0d8a1fb1fda470d81acecb2dba057a481d"
@@ -7893,6 +7906,11 @@ through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+tiny-inflate@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tinycolor2@^1.4.1:
   version "1.4.1"
@@ -8314,6 +8332,13 @@ warning@^3.0.0:
   integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
   dependencies:
     loose-envify "^1.0.0"
+
+wawoff2@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/wawoff2/-/wawoff2-2.0.1.tgz#474d8ccae33da3863abad0ee64b70b6db51acac2"
+  integrity sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==
+  dependencies:
+    argparse "^2.0.1"
 
 web-encoding@1.1.5:
   version "1.1.5"


### PR DESCRIPTION
When exporting an SVG with Carbon, embedding it in software like PowerPoint doesn't work. This is because dom-to-image uses a tag called foreignObject to embed HTML into the SVG, but this feature seems to only be supported in browsers. This issue was resolved by creating the SVG ourselves. Custom font support was added by directly drawing the glyphs onto the SVG.

The PNG export had a bug where text unnecessarily wrapped to the next line. This was fixed by generating an SVG and rendering it onto a canvas.

Importing react-codemirror2 caused server-side errors due to inadequate internal checks in the library to determine if it was running in a browser environment. This was resolved by adding a wrapper that checks if document is defined before requiring the module.

Windows development was not possible before (something to do with the webpack plugin that removes the default codemirror CSS). A devcointainer file was added to mitigate this.

Note: I couldn’t test Twitter export functionality because I lack API keys. If anyone can test this, please let me know if there are issues!